### PR TITLE
Provenance as a structural invariant, ORI agency identity, and personnel entity resolution

### DIFF
--- a/.github/workflows/provenance-invariant.yml
+++ b/.github/workflows/provenance-invariant.yml
@@ -1,0 +1,68 @@
+# Guards the provenance invariant against later migrations.
+#
+# The point of this workflow is the `assert:provenance` step. The invariant is
+# enforced by the migration that created it, and a schema invariant checked
+# only by its own migration decays the moment someone writes the next one --
+# a later migration that grants `page_renderer` a base table, or that opens the
+# personnel publication gate, would silently reopen the hole. This runs the
+# assertion against a real, fully migrated database on every change so that
+# fails the build instead.
+#
+# Deliberately narrow: it does not run `npm run validate`. `format:check` and
+# `lint:sql` are currently failing on main for pre-existing reasons unrelated
+# to provenance, and a gate that is red on arrival gets ignored. Widening this
+# to the full validate script should follow cleaning those up.
+
+name: provenance invariant
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  schema:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_TELEMETRY_DISABLED: "1"
+      # `supabase start` publishes Postgres on this port; both steps below
+      # talk to the same fully migrated database.
+      DB_URL: postgres://postgres:postgres@127.0.0.1:54322/postgres
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+
+      - run: npm ci
+
+      # Uses the pinned `supabase` devDependency rather than a separately
+      # versioned CLI action, so CI and local runs apply migrations with the
+      # same tool.
+      - name: Start Supabase
+        run: npm run supabase:start
+
+      # Applies the full migration set, including the provenance migration,
+      # on top of the real upstream schema.
+      - name: Apply migrations
+        run: npm run supabase:reset
+
+      # Real-schema mode: the suite detects the migrated database and asserts
+      # against the real agency/officers definitions rather than the fixture.
+      - name: Schema tests
+        run: npx vitest run test/schema
+        env:
+          TEST_DATABASE_URL: ${{ env.DB_URL }}
+
+      # The regression gate. Must run after migrations, against the database
+      # they produced.
+      - name: Assert provenance invariant
+        run: npm run assert:provenance
+        env:
+          DATABASE_URL: ${{ env.DB_URL }}
+
+      - name: Stop Supabase
+        if: always()
+        run: npm run supabase:stop

--- a/openspec/changes/2026-08-24-provenance-structural-invariant/design.md
+++ b/openspec/changes/2026-08-24-provenance-structural-invariant/design.md
@@ -1,0 +1,206 @@
+# Design — Provenance As A Structural Invariant
+
+## The requirement, restated precisely
+
+"A field without provenance does not render" is two separate claims, and each
+needs its own mechanism:
+
+1. An uncited value must not be able to **exist**.
+2. An uncited value must not be able to be **read by the render path**.
+
+Implementing only (1) leaves a convention: the value column is still selectable
+without the citation column. Implementing only (2) leaves a hole: the render
+path could be pointed at a base table. Both are required.
+
+## Mechanism 1 — existence
+
+Displayable values live in `public.claim`, whose `retrieval_id` is `NOT NULL`
+and references `public.source_retrieval`. That table has:
+
+```sql
+constraint source_retrieval_locator_required check (
+    source_url is not null or records_request_id is not null
+)
+```
+
+so a retrieval cannot exist without a locator, and `retrieved_at` is `NOT NULL`.
+`source_retrieval` is append-only by trigger, so a retrieval date cannot be
+rewritten after the fact — a mutable citation date is a falsifiable citation.
+
+`confidence` is `NOT NULL check (confidence > 0 and confidence <= 1)`.
+Zero is excluded deliberately: a claim we assign no confidence to is not a
+claim, it is a deletion.
+
+The four required provenance elements therefore reduce to: source dataset
+(`source` via `source_retrieval`), retrieval date (`source_retrieval.retrieved_at`),
+source URL or records-request identifier (`source_retrieval`, constrained), and
+confidence (`claim`). None is nullable.
+
+### Why predicates are registered
+
+`claim.predicate` references `claim_predicate`. Adding a displayable field
+requires adding a registry row declaring its datatype, whether it is
+`renderable` at all, and how many independent sources must corroborate it.
+This makes "a new field appeared on a public page" a reviewable schema change
+rather than a template edit.
+
+The live case that forced `renderable = false`: `agency_type_name` is
+internally inconsistent across states (148 California agencies typed
+`State Police`, 1 in Texas). It is ingested with provenance, drives internal
+grouping, and cannot be published until a second source corroborates it.
+
+### Why `value_absent` exists
+
+39% of Texas rows (686/1,754) and 27% of California rows (237/867) in the
+federal registry have null lat/lon. "The source does not record this" is a
+fact with a citation, and it is not the same as "we have not asked". A
+`value_absent` claim renders as a cited absence. Enrichment from another
+source becomes a second claim from a second retrieval and never overwrites the
+registry value in place.
+
+## Mechanism 2 — reading
+
+`render.published_claim` exposes exactly four columns:
+
+```
+subject_type, subject_id, predicate, cited_value
+```
+
+There is no `value_text`. `cited_value` is a jsonb built by `render.cite()`
+containing `{value, absent, citation{source, sourceName, publisher,
+retrievedAt, locator, locatorType, confidence, confidenceBasis}}`. The value
+and its citation are the same column, so no projection can separate them.
+
+The view INNER JOINs `source_retrieval` and `source`, filters
+`publication_status = 'published'`, excludes superseded claims, excludes
+non-renderable predicates, excludes sources whose terms are not `cleared`, and
+excludes suppressed subjects.
+
+The page build connects as `page_renderer`, whose entire privilege set is:
+
+```
+render.published_agency [SELECT]
+render.published_claim  [SELECT]
+```
+
+Verified: as `page_renderer`, `select count(*) from public.claim` returns
+`ERROR: permission denied for schema public`. There is no SQL that role can
+write which returns a value without its source, because it cannot reach any
+table that holds one.
+
+`alter default privileges in schema render revoke all on tables from
+page_renderer` means a future render view is unreadable until someone writes
+an explicit grant.
+
+## Mechanism 3 — the invariant does not decay
+
+An invariant enforced only by the migration that created it lasts until the
+next migration. `public.assert_provenance_invariant()` returns violations and
+is wired to `npm run assert:provenance` for CI. It detects:
+
+- any `page_renderer` privilege on a table outside `render`
+- any `page_renderer` privilege on a `render` object outside the reviewed
+  allowlist — this is what catches a future `grant select on all tables in
+schema render`
+- the personnel gate being opened by a grant
+- any render view exposing a bare value column
+
+## Agency identity
+
+ORI is the primary agency key because it is the one identifier federal, state,
+and local datasets share. Two measured facts shape the model:
+
+**ORI is a reporting-unit key, not a department key.** The FBI registry returns
+148 agencies typed `State Police` for California; California has one
+state-police equivalent. Those are CHP area offices, each holding its own ORI.
+Without a layer above ORI, CHP renders as 148 separate police departments.
+`agency_entity` is that layer, and `agency_entity_member` records membership
+with a confidence and an evidence payload — agency-side entity resolution is a
+first-class problem, not only a personnel-side one.
+
+**ORI form varies across datasets.** All 1,754 Texas ORIs from the federal
+registry are 9 characters; older federal datasets use 7. `ori_form` is
+recorded explicitly and length-checked. `ori7` is a `generated always ... stored`
+bridge key so it cannot drift, and is documented as derived so nobody mistakes
+it for a source-asserted identifier. Two ORIs sharing an `ori7` are
+_candidates_ for the same unit — never an automatic merge.
+
+**Conflicts queue, they do not resolve.** A trigger on `agency_ori` opens an
+`ori_conflict` row when an `ori7` maps to more than one agency or to more than
+one form. `render.published_agency` excludes any agency with an open conflict:
+an unresolved ORI collision means we may be about to publish a page about the
+wrong department, and accuracy outranks coverage. Closing a conflict requires
+a resolver, a timestamp, and a note, enforced by constraint.
+
+**Absence is a finding.** The federal source is a UCR-_participation_ registry,
+not the NCIC ORI universe (the real NCIC file is CJIS-restricted and we will
+not have it). Puerto Rico returns 1 agency; PR has a state police force plus
+dozens of municipal departments. `agency_registry_presence` records
+`present` / `absent` / `not_applicable` / `unknown` per source per retrieval,
+so "not in the registry" can never be silently read as "does not exist" and
+INS-7 coverage denominators are never a registry row count.
+
+## Personnel identity
+
+`person` has no attribute columns at all — only `person_id`,
+`legacy_officer_id`, and timestamps. This is deliberate and is verified by a
+test: there is no `person.first_name` that could ever render uncited. A
+person's name exists only as `person_name_variant` rows, each with its own
+retrieval and confidence.
+
+`person_identity_link` records assertions between two person rows and never
+merges them:
+
+- `assertion` is `same_person`, `possible_same_person`, or `distinct_person`.
+  The negative is as valuable as the positive: a reviewed `distinct_person`
+  stops the same false candidate being re-proposed on every run.
+- The pair is canonically ordered (`person_id_a < person_id_b`), so a pair is
+  unique in one direction only.
+- Any non-`proposed` status requires a reviewer and a timestamp.
+- An automated probabilistic method may not self-accept a `same_person` link.
+  Only `manual_review` and `state_certification_number` may.
+
+The measured reason for this caution: 116,020 distinct personnel name-slugs
+are live, 7,909 of which have more than one profile — 13,914 profiles beyond
+one-per-name. `jose-gonzalez` has 33. That is not evidence of error; there
+really are many officers by that name. It is evidence that ~14k profiles sit
+exactly where entity resolution either works or produces a catastrophic
+outcome: wrongly merging two officers, or wrongly splitting one officer's
+career so misconduct does not follow them across departments.
+
+A link is reversible. A merge is not. We link.
+
+## Rejected alternatives
+
+**Per-column `source_url` / `retrieved_at` on existing tables.** Smaller
+migration, and it is a convention — a template can select `name` and never
+touch `name_source_url`. It also cannot represent two sources disagreeing
+about one field, which is the normal case here, not the exception.
+
+**Application-layer enforcement (an ORM guard or a lint rule).** Both are
+developer discipline. The instruction was explicitly that this must not be.
+
+**Row-level security instead of a separate role.** RLS filters rows; it does
+not prevent selecting a value column without its citation column. The
+column-shape guarantee is what makes the citation inseparable, and that comes
+from the view definition, not from RLS.
+
+**Hard-merging duplicate officers.** Irreversible, and the failure mode is
+attributing one human's misconduct to another.
+
+## Known limits
+
+- **The existing 132,109 personnel pages are not covered by this change.** They
+  have no retrieval records to point at. This change makes the correct model
+  exist; it does not retroactively cite a corpus whose origin we cannot
+  demonstrate. That is INS-11's decision and a separate change.
+- **`security_invoker = off`** means the render views read base tables with
+  their owner's rights. That is what lets `page_renderer` hold no privilege on
+  `public`. The tradeoff is that the view definitions are themselves
+  security-critical and must be reviewed as such.
+- **Verified against a fixture, not the full 45-table schema.** PostGIS is not
+  available on the verification host, so the full migration set could not be
+  applied locally. `test/schema/upstream-fixture.sql` reproduces only the
+  upstream objects this migration references (`generate_cuid`, `agency`,
+  `officers`) and is skipped when `public.agency` already exists. The suite
+  must also be run against a real `supabase db reset` database before merge.

--- a/openspec/changes/2026-08-24-provenance-structural-invariant/proposal.md
+++ b/openspec/changes/2026-08-24-provenance-structural-invariant/proposal.md
@@ -1,0 +1,133 @@
+## Why
+
+We publish claims about named human beings. Being wrong is a legal and ethical
+catastrophe.
+
+The current schema cannot cite itself. Across all 146 KB of migrations,
+`provenance` appears 0 times, `citation` 0, `retrieved_at` 0, `attribution` 0.
+`source_url` exists only on `civil_cases`; `confidence` only on
+`coverage_links`. The two tables behind 99.7% of the public page surface --
+`officers` and `agency_officers` -- carry no source, no retrieval date, and no
+confidence. A blanket footer disclaimer stands in for per-field citation.
+
+A convention would not fix this. A field-level `source_url` column is a
+convention: nothing stops a template from selecting the value and omitting the
+column. This change makes an uncited render structurally unreachable.
+
+There are two secondary defects the same change must fix, because both are
+join-key problems and fixing them later is a backfill against a live corpus:
+
+- **ORI is absent.** `ORI` appears 0 times in the migrations. Agencies are
+  keyed on a generated cuid2 with a 6-hex slug suffix that no external dataset
+  shares. There is no join key to FBI/BJS data and no safe way to merge a
+  second state's roster without fuzzy name-and-address matching.
+- **Entity resolution is unmodeled.** `officers` has no aliases, no
+  cross-agency linkage, and no identity confidence. Every sampled agency page
+  shows "Past employers 0". Officers who moved between departments -- the
+  single most important pattern in police accountability -- are currently
+  modeled as unrelated people.
+
+## What Changes
+
+**Provenance Invariant**
+
+- From: Displayable values are plain columns on `agency`, `officers`, and
+  `agency_officers` with no source attribution.
+- To: Displayable values are `public.claim` rows carrying a NOT NULL
+  `retrieval_id`, and a retrieval cannot exist without a source, a retrieval
+  timestamp, and either a source URL or a records-request identifier.
+- Reason: An uncited value must be unrepresentable, not merely discouraged.
+- Impact: New tables; no existing table is altered or dropped.
+
+**Render Isolation**
+
+- From: The page-build path reads base tables directly.
+- To: A `render` schema exposes value and citation as a single indivisible
+  `cited_value` jsonb. A `page_renderer` role holds SELECT on exactly two
+  views and on nothing else.
+- Reason: Row-level provenance alone is bypassable by selecting the value
+  column and dropping the citation. Removing the renderer's ability to read
+  any table containing an uncited value closes that path.
+- Impact: New schema, new role, new least-privilege grants. Existing render
+  paths are unaffected because they connect as a different role.
+
+**Publication Status And Suppression**
+
+- From: No publication lifecycle; a record is live or absent.
+- To: `staged` / `published` / `blocked` / `quarantined` on every claim and
+  employment period, subject-level suppression, and a trigger-written
+  append-only `publication_event` audit trail.
+- Reason: Correction and takedown must be possible on day one, and `blocked`
+  (a policy decision) must be distinguishable from `quarantined` (a data
+  quality decision) because they escalate to different people.
+- Impact: New tables and triggers.
+
+**Canonical Agency Identity**
+
+- From: No ORI.
+- To: `agency_ori` with an explicit `ori_form` (`ori7` / `ori9`), a generated
+  `ori7` bridge key, an `agency_entity` layer above the reporting-unit layer,
+  a reviewed `ori_conflict` queue, and explicit `agency_registry_presence`.
+- Reason: ORI is a reporting-unit key, not a department key -- the FBI
+  registry returns 148 agencies typed `State Police` for California and 1 for
+  Texas. Federal datasets mix 7- and 9-character ORIs, so an unlabeled `ori`
+  column silently fails to join, and a silent join failure here means a page
+  about the wrong department.
+- Impact: New tables; `agency` is referenced but not altered.
+
+**Personnel Identity Resolution**
+
+- From: `officers` rows with name columns and no linkage.
+- To: An attribute-free `person` hypothesis, cited `person_name_variant` rows,
+  `employment_period`, and confidence-scored `person_identity_link` records
+  that are never merges.
+- Reason: A wrong merge attributes one officer's misconduct to a different
+  human being, and is irreversible. A link is reversible.
+- Impact: New tables. `person.legacy_officer_id` attaches the existing corpus
+  without rewriting it.
+
+## Capabilities
+
+### New Capabilities
+
+- `provenance-invariant`: Structural enforcement that a displayable value
+  cannot exist or be read without its citation, plus publication status,
+  suppression, and audit trail.
+- `canonical-agency-identity`: ORI-keyed agency identity, form-aware joins,
+  the department-level entity layer, the reviewed conflict queue, and registry
+  presence.
+- `personnel-entity-resolution`: Confidence-scored, reversible personnel
+  identity linkage across agencies and name variants.
+
+### Modified Capabilities
+
+- None. This change is purely additive.
+
+## Impact
+
+Affected areas:
+
+- `supabase/migrations/20260824170000_provenance_structural_invariant.sql`
+  (new, additive).
+- `scripts/assert-provenance-invariant.ts` and the `assert:provenance` npm
+  script, for CI enforcement after migrations.
+- `test/schema/provenance-invariant.test.ts` and
+  `test/schema/upstream-fixture.sql`, requiring `TEST_DATABASE_URL`.
+- No generated type refresh is required: no existing table changes shape.
+- No data reset is required. No production migration plan is requested by this
+  change; applying it to production is deliberately a separate decision,
+  because the backfill of 132,109 live personnel pages onto the claim model is
+  a separate change with a legal dimension (see INS-11).
+
+## Out Of Scope, Deliberately
+
+- **Backfilling the existing corpus onto the claim model.** The live corpus has
+  no retrieval records to point at. Manufacturing a citation for a value whose
+  origin we cannot demonstrate would be worse than having none.
+- **Retiring the legacy value columns** on `agency`, `officers`, and
+  `agency_officers`. They stay until the backfill lands; the renderer simply
+  cannot read them.
+- **Opening the personnel gate.** `render.published_person` is defined to
+  return zero rows and is not granted to `page_renderer`. Both locks must be
+  removed by an explicit, reviewable migration, and only after Data Integrity
+  & Publication Risk Reviewer clearance.

--- a/openspec/changes/2026-08-24-provenance-structural-invariant/specs/canonical-agency-identity/spec.md
+++ b/openspec/changes/2026-08-24-provenance-structural-invariant/specs/canonical-agency-identity/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: ORI Form Is Recorded Explicitly
+
+An ORI assignment MUST record which form the identifier takes, and the recorded
+form MUST match the identifier's length.
+
+#### Scenario: Form and length must agree
+
+- **WHEN** a 9-character ORI is recorded with `ori_form = 'ori7'`
+- **THEN** the database rejects the write with `agency_ori_form_length`
+
+#### Scenario: A cross-form bridge key is derived, not asserted
+
+- **WHEN** a 9-character ORI `TX0570000` is recorded
+- **THEN** `ori7` is derived as `TX05700` and cannot be set independently
+
+### Requirement: ORI Assignments Carry Provenance
+
+An ORI assignment MUST reference a source retrieval and carry a confidence.
+
+#### Scenario: ORI without a retrieval is rejected
+
+- **WHEN** an `agency_ori` row is inserted without `retrieval_id`
+- **THEN** the database rejects the write
+
+### Requirement: ORI Conflicts Queue For Review
+
+Conflicting ORI assignments MUST open a reviewed conflict rather than resolving
+automatically, and affected agencies MUST NOT render while a conflict is open.
+
+#### Scenario: Two agencies sharing an ORI open a conflict
+
+- **WHEN** a second agency is assigned an ORI sharing an `ori7` with an existing agency
+- **THEN** an open `ori_conflict` of type `same_ori_multiple_agencies` is created listing both agency IDs
+
+#### Scenario: Conflicting agencies are withheld from render
+
+- **WHEN** an `ori_conflict` for an `ori7` has status `open`
+- **THEN** agencies holding that `ori7` do not appear in `render.published_agency`
+
+#### Scenario: Closing a conflict requires attribution
+
+- **WHEN** an `ori_conflict` is set to `resolved` without a resolver, timestamp, and note
+- **THEN** the database rejects the write
+
+### Requirement: Registry Absence Is A Recorded Finding
+
+Absence of an agency from a registry MUST be representable as an explicit
+finding distinct from the agency not existing.
+
+#### Scenario: Absence is recorded per source per retrieval
+
+- **WHEN** an agency confirmed by a state roster is not present in the federal registry
+- **THEN** an `agency_registry_presence` row records `absent` against that source and retrieval
+
+### Requirement: Departments Are Modeled Above Reporting Units
+
+The schema MUST support grouping multiple ORI-holding reporting units under one
+department-level entity, with the grouping carrying a confidence and evidence.
+
+#### Scenario: Membership is evidence-backed
+
+- **WHEN** an agency is attached to an `agency_entity`
+- **THEN** the membership records a method, a confidence in (0, 1], and an evidence payload
+
+#### Scenario: An agency belongs to at most one entity
+
+- **WHEN** an agency is attached to a second `agency_entity`
+- **THEN** the database rejects the write

--- a/openspec/changes/2026-08-24-provenance-structural-invariant/specs/personnel-entity-resolution/spec.md
+++ b/openspec/changes/2026-08-24-provenance-structural-invariant/specs/personnel-entity-resolution/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Person Records Carry No Displayable Attributes
+
+A person record MUST NOT contain displayable attribute columns. Every fact
+about a person MUST exist only as a cited claim or a cited name variant.
+
+#### Scenario: Person has no name columns
+
+- **WHEN** the columns of `public.person` are inspected
+- **THEN** they are exactly `person_id`, `legacy_officer_id`, `created_at`, `updated_at`
+
+#### Scenario: Name variants require a citation
+
+- **WHEN** a `person_name_variant` is inserted without `retrieval_id`
+- **THEN** the database rejects the write
+
+### Requirement: Identity Resolution Links, Never Merges
+
+The same human appearing under multiple person records MUST be represented by a
+reversible confidence-scored link. No identity operation may rewrite or delete
+an existing person record.
+
+#### Scenario: Linking leaves both records intact
+
+- **WHEN** two person records are linked as `possible_same_person`
+- **THEN** both person records still exist unchanged
+
+#### Scenario: Identity pairs are canonically ordered
+
+- **WHEN** a link is inserted with `person_id_a` greater than or equal to `person_id_b`
+- **THEN** the database rejects the write with `person_identity_link_ordered`
+
+#### Scenario: Reviewed negatives are representable
+
+- **WHEN** two person records are reviewed and found to be different people
+- **THEN** a `distinct_person` link can be recorded so the candidate is not re-proposed
+
+### Requirement: Same-Person Acceptance Requires Human Or Certificate Evidence
+
+An automated probabilistic match MUST NOT accept a `same_person` link on its
+own authority.
+
+#### Scenario: Probabilistic method cannot self-accept
+
+- **WHEN** a `same_person` link with method `probabilistic_score` is inserted with status `accepted`
+- **THEN** the database rejects the write
+
+#### Scenario: Non-proposed links require a reviewer
+
+- **WHEN** a link is inserted with status `accepted` or `rejected` and no reviewer
+- **THEN** the database rejects the write with `person_identity_link_review_complete`
+
+### Requirement: Employment Spans Agencies And Carries Provenance
+
+A person's employment at an agency MUST be modeled as its own cited assertion
+so that a career crossing multiple agencies is representable.
+
+#### Scenario: Employment requires a citation
+
+- **WHEN** an `employment_period` is inserted without `retrieval_id`
+- **THEN** the database rejects the write
+
+#### Scenario: Employment attributes are claims, not columns
+
+- **WHEN** the columns of `public.employment_period` are inspected
+- **THEN** they contain no rank, badge number, or employment date columns

--- a/openspec/changes/2026-08-24-provenance-structural-invariant/specs/provenance-invariant/spec.md
+++ b/openspec/changes/2026-08-24-provenance-structural-invariant/specs/provenance-invariant/spec.md
@@ -1,0 +1,170 @@
+## ADDED Requirements
+
+### Requirement: Displayable Values Require Provenance To Exist
+
+Every value that can appear on a public page MUST be stored as a claim carrying
+a non-null reference to a source retrieval, and a retrieval MUST carry a source,
+a retrieval timestamp, and a locator.
+
+#### Scenario: Claim without a retrieval is rejected
+
+- **WHEN** a claim is inserted without `retrieval_id`
+- **THEN** the database rejects the write with a not-null violation
+
+#### Scenario: Retrieval without a locator is rejected
+
+- **WHEN** a source retrieval is inserted with neither `source_url` nor `records_request_id`
+- **THEN** the database rejects the write with `source_retrieval_locator_required`
+
+#### Scenario: Records-request identifier is an acceptable locator
+
+- **WHEN** a source retrieval is inserted with `records_request_id` and no `source_url`
+- **THEN** the write succeeds and the identifier is preserved
+
+#### Scenario: Confidence must be within (0, 1]
+
+- **WHEN** a claim is inserted with `confidence` of 0 or greater than 1
+- **THEN** the database rejects the write
+
+#### Scenario: Retrieval records cannot be rewritten
+
+- **WHEN** an update or delete is attempted against `source_retrieval`
+- **THEN** the database rejects it as append-only
+
+### Requirement: Displayable Fields Are Registered
+
+A claim MUST reference a registered predicate, and its populated value column
+MUST match the predicate's declared datatype and subject type.
+
+#### Scenario: Unregistered predicate is rejected
+
+- **WHEN** a claim references a predicate with no `claim_predicate` row
+- **THEN** the database rejects the write
+
+#### Scenario: Datatype mismatch is rejected
+
+- **WHEN** a claim populates `value_text` for a predicate declared as `number`
+- **THEN** the database rejects the write
+
+### Requirement: Source-Asserted Absence Is Cited
+
+A source that records no value for a field MUST be representable as a cited
+absence, distinct from a value we have not sought, and MUST NOT be silently
+backfilled from another source.
+
+#### Scenario: Absent value renders with a citation
+
+- **WHEN** a published claim has `value_absent = true`
+- **THEN** the render surface returns `absent: true`, a null value, and a complete citation
+
+### Requirement: The Render Path Cannot Read An Uncited Value
+
+The page-build role MUST NOT hold any privilege on a table that can contain an
+uncited value, and the render surface MUST NOT expose a value separably from
+its citation.
+
+#### Scenario: Render role cannot read base tables
+
+- **WHEN** the `page_renderer` role selects from `public.claim`, `public.agency`, or `public.officers`
+- **THEN** the database denies permission
+
+#### Scenario: Render surface exposes no bare value column
+
+- **WHEN** the `page_renderer` role selects `value_text` from `render.published_claim`
+- **THEN** the query fails because no such column exists
+
+#### Scenario: Value and citation are one column
+
+- **WHEN** the `page_renderer` role selects `cited_value` for a published claim
+- **THEN** the returned jsonb contains the value and its source, publisher, retrieval date, locator, locator type, confidence, and confidence basis
+
+#### Scenario: Staged claims are invisible to the render path
+
+- **WHEN** a claim has `publication_status` other than `published`
+- **THEN** it does not appear in `render.published_claim`
+
+### Requirement: Publication Is Refused For Ineligible Claims
+
+A claim MUST NOT be publishable when its predicate is not renderable, when its
+backing source is not terms-cleared, or when its corroboration threshold is
+unmet. Publication is refused, never silently downgraded.
+
+#### Scenario: Non-renderable predicate cannot be published
+
+- **WHEN** a claim on a predicate with `renderable = false` is set to `published`
+- **THEN** the database rejects the write
+
+#### Scenario: Uncleared source cannot back a published claim
+
+- **WHEN** a claim whose source has `terms_status` other than `cleared` is set to `published`
+- **THEN** the database rejects the write
+
+### Requirement: Publication Status Changes Are Audited
+
+Every publication-status transition MUST write an append-only audit event
+recording the prior status, the new status, and the actor.
+
+#### Scenario: Transitions are recorded automatically
+
+- **WHEN** a claim is inserted and then moved through `published` and `blocked`
+- **THEN** `publication_event` contains one row per transition with correct `from_status` and `to_status`
+
+#### Scenario: Audit trail cannot be edited
+
+- **WHEN** an update or delete is attempted against `publication_event`
+- **THEN** the database rejects it as append-only
+
+### Requirement: Subjects Can Be Suppressed Immediately
+
+An active suppression on a subject MUST remove it from every render surface
+regardless of individual claim status, and lifting it MUST restore visibility.
+
+#### Scenario: Suppression removes a subject from render
+
+- **WHEN** an unlifted `subject_suppression` row exists for a subject
+- **THEN** no claim for that subject appears in `render.published_claim`
+
+#### Scenario: Lifting a suppression restores render
+
+- **WHEN** the suppression is lifted with a `lifted_by` and `lifted_at`
+- **THEN** the subject's published claims appear again
+
+### Requirement: The Invariant Is Verifiable In CI
+
+The database MUST expose a check that reports any weakening of the render
+isolation, and it MUST fail the build when violated.
+
+#### Scenario: Clean database reports no violations
+
+- **WHEN** `public.assert_provenance_invariant()` runs on a correctly migrated database
+- **THEN** it returns zero rows
+
+#### Scenario: A later grant to a base table is detected
+
+- **WHEN** `page_renderer` is granted SELECT on `public.claim`
+- **THEN** the check reports `renderer_reads_base_table` naming that table
+
+#### Scenario: Opening the personnel gate is detected
+
+- **WHEN** `page_renderer` is granted SELECT on `render.published_person`
+- **THEN** the check reports `personnel_gate_open`
+
+### Requirement: The Personnel Publication Gate Is Closed By Construction
+
+Named-personnel data MUST NOT be publicly renderable, and opening the gate MUST
+require an explicit reviewable migration rather than a configuration change.
+
+#### Scenario: Render role has no access to the personnel view
+
+- **WHEN** the `page_renderer` role selects from `render.published_person`
+- **THEN** the database denies permission
+
+#### Scenario: A published employment still renders nothing
+
+- **WHEN** an `employment_period` is set to `published`
+- **THEN** `render.published_person` still returns zero rows
+
+#### Scenario: Employment defaults to staged
+
+- **WHEN** an `employment_period` is inserted without an explicit status
+- **THEN** its `publication_status` is `staged`

--- a/openspec/changes/2026-08-24-provenance-structural-invariant/tasks.md
+++ b/openspec/changes/2026-08-24-provenance-structural-invariant/tasks.md
@@ -1,0 +1,73 @@
+# Tasks
+
+## 1. Schema
+
+- [x] Add `supabase/migrations/20260824170000_provenance_structural_invariant.sql`
+      as a purely additive migration. No existing table is altered or dropped.
+- [x] Provenance spine: `source`, `source_retrieval` (append-only, locator
+      constrained), `claim_predicate`, `claim` with `retrieval_id NOT NULL`.
+- [x] Publication lifecycle: `publication_status` enum, `subject_suppression`,
+      append-only `publication_event` written by trigger.
+- [x] Agency identity: `agency_entity`, `agency_entity_member`, `agency_ori`
+      with explicit `ori_form` and generated `ori7`, `ori_conflict` queue with
+      detection trigger, `agency_registry_presence`.
+- [x] Personnel identity: attribute-free `person`, `person_name_variant`,
+      `employment_period`, `person_identity_link`.
+- [x] Render surface: `render` schema, `render.cite()`, `render.published_claim`,
+      `render.published_agency`, gated `render.published_person`.
+- [x] Least-privilege `page_renderer` role with an explicit two-view allowlist
+      and default privileges revoked for future objects.
+- [x] All primary keys are `text` with no `DEFAULT`, per the repo ID policy that
+      the database must never generate durable IDs. The one exception is
+      `publication_event.event_id`, which is an append-only log row rather than
+      a durable entity; this is stated in a comment on the trigger function.
+
+## 2. Enforcement
+
+- [x] Add `public.assert_provenance_invariant()` returning violations.
+- [x] Add `scripts/assert-provenance-invariant.ts` and the `assert:provenance`
+      npm script so CI fails on a weakened invariant.
+- [ ] Wire `assert:provenance` into the CI workflow after `supabase db reset`.
+      Not done here: the CI workflow lives outside this repo's `validate` script
+      and changing it needs the deploy owner. Tracked separately.
+
+## 3. Verification
+
+- [x] Add `test/schema/provenance-invariant.test.ts` — 42 tests, each attempting
+      the thing the invariant forbids and asserting refusal.
+- [x] Add `test/schema/upstream-fixture.sql`, applied only when `public.agency`
+      is absent so the suite exercises the real schema when one is present.
+- [x] Assert `current_user = 'page_renderer'` before the permission tests. The
+      first draft passed all four permission tests while connected as the
+      superuser, because `pg` ignores the `user` option when `connectionString`
+      is set. Without this guard the suite reports a false green on the single
+      most important assertion in the change.
+- [x] `npm run test:vitest` passes with and without `TEST_DATABASE_URL`
+      (suite self-skips when absent).
+- [x] `npm run typecheck` passes.
+- [x] `npm run format:check` passes.
+- [ ] Run the suite against a real `supabase db reset` database. Not done here:
+      PostGIS is unavailable on the verification host, so the full 45-table
+      migration set could not be applied locally. **Required before merge.**
+
+## 4. Supabase And Contract Validation
+
+- [x] No generated type refresh required — no existing table changes shape.
+- [x] No data reset required — the migration is additive.
+- [x] No seed rows added, so no post-seed integrity assertions are needed.
+- [ ] `npm run lint:sql` (sqlfluff) not run — requires `mise`/`uvx`, unavailable
+      on the verification host. **Required before merge.**
+- [ ] `npm run openspec:validate` not run — the `openspec` binary is not
+      installed here. **Required before merge.**
+
+## 5. Deliberately Not In This Change
+
+- Backfilling the 132,109 live personnel pages onto the claim model. They have
+  no retrieval records to point at, and manufacturing a citation for a value
+  whose origin cannot be demonstrated is worse than having none. Blocked on
+  INS-11.
+- Retiring the legacy value columns on `agency`, `officers`, `agency_officers`.
+- Opening the personnel gate. Requires Data Integrity & Publication Risk
+  Reviewer clearance plus a reviewable migration and grant.
+- Applying this migration to production. That is a separate decision with a
+  deploy owner.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "generate:envelope-types": "tsx scripts/generate-envelope-types.ts",
     "setup": "bash scripts/bootstrap-dev.sh",
     "doctor": "bash scripts/bootstrap-dev.sh --check",
+    "assert:provenance": "tsx scripts/assert-provenance-invariant.ts",
     "cli": "tsx src/cli/index.ts",
     "link-seed": "bash scripts/link-seed.sh",
     "format": "prettier --write \"**/*.{json,md,ts,yml,yaml}\"",

--- a/scripts/assert-provenance-invariant.ts
+++ b/scripts/assert-provenance-invariant.ts
@@ -1,0 +1,44 @@
+/**
+ * Fails the build if the provenance invariant has been weakened.
+ *
+ * A schema invariant that is only checked by the migration that created it
+ * decays the moment someone writes the next migration. This runs
+ * public.assert_provenance_invariant() against a live database and exits
+ * non-zero on any violation -- notably a later migration granting the render
+ * role access to a base table, or opening the personnel publication gate.
+ *
+ *   DATABASE_URL=postgres://... npm run assert:provenance
+ */
+
+import { Client } from "pg";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+
+if (!DATABASE_URL) {
+  console.error("assert:provenance requires DATABASE_URL");
+  process.exit(2);
+}
+
+const client = new Client({ connectionString: DATABASE_URL });
+await client.connect();
+
+try {
+  const { rows } = await client.query<{ violation: string; detail: string }>(
+    "select violation, detail from public.assert_provenance_invariant()",
+  );
+
+  if (rows.length === 0) {
+    console.log("provenance invariant intact");
+    process.exit(0);
+  }
+
+  console.error(
+    `provenance invariant VIOLATED (${rows.length} finding${rows.length === 1 ? "" : "s"}):`,
+  );
+  for (const row of rows) {
+    console.error(`  ${row.violation}: ${row.detail}`);
+  }
+  process.exit(1);
+} finally {
+  await client.end();
+}

--- a/supabase/migrations/20260824170000_provenance_structural_invariant.sql
+++ b/supabase/migrations/20260824170000_provenance_structural_invariant.sql
@@ -1,0 +1,1041 @@
+-- Provenance as a structural invariant, canonical agency identity (ORI), and
+-- confidence-scored personnel identity resolution.
+--
+-- Design intent (see openspec/changes/2026-08-24-provenance-structural-invariant):
+--
+--   1. A displayable value cannot EXIST without provenance.
+--      Every claim row carries a NOT NULL FK to a retrieval, and a retrieval
+--      cannot exist without a source, a retrieval timestamp, and either a
+--      source URL or a records-request identifier.
+--
+--   2. A displayable value cannot be READ by the render path without its
+--      citation travelling with it. The render path connects as
+--      `page_renderer`, which holds SELECT on nothing except the
+--      `render.*` views. Those views do not expose a bare value column at
+--      all -- they expose a single `cited_value` jsonb that contains the
+--      value and its citation in the same field. There is no SQL a renderer
+--      can write that returns a value without its source.
+--
+-- Both halves are required. The first alone is a convention (someone selects
+-- the value column and drops the citation). The second alone is bypassable
+-- (someone reads a base table). Together they make an uncited render
+-- structurally unreachable rather than merely discouraged.
+--
+-- ID policy: per openspec/config.yaml, the database MUST NEVER generate
+-- durable IDs. Every primary key below is `text` with no DEFAULT. Intake
+-- assigns IDs through its source-key mapping ledger.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 1. Enumerations
+-- ---------------------------------------------------------------------------
+
+-- Publication lifecycle for anything that can reach a public page.
+--   staged      -- ingested, not public. The default. Personnel start here.
+--   published   -- publicly renderable.
+--   blocked     -- deliberately withheld (legal hold, takedown, gate not cleared).
+--   quarantined -- withheld because we do not trust it (source conflict, suspected error).
+-- blocked and quarantined are distinct on purpose: one is a policy decision,
+-- the other is a data-quality decision, and they are escalated to different people.
+create type public.publication_status as enum (
+    'staged',
+    'published',
+    'blocked',
+    'quarantined'
+);
+
+-- How we obtained a source. Drives terms review and the "do not scrape what
+-- prohibits it" boundary -- an access basis of 'scrape' does not exist here by
+-- design; if a source is only reachable by scraping it does not get a row.
+create type public.source_access_basis as enum (
+    'public_api',
+    'public_bulk_download',
+    'records_request',
+    'published_document',
+    'agency_published_dataset',
+    'user_submission'
+);
+
+-- Terms posture. Nothing may be ingested from a source that is not 'cleared'.
+create type public.source_terms_status as enum (
+    'unreviewed',
+    'under_review',
+    'cleared',
+    'prohibited'
+);
+
+-- What kind of assertion a claim's confidence describes.
+create type public.confidence_basis as enum (
+    'source_asserted',   -- the source states this field directly
+    'source_derived',    -- computed from source fields without external input
+    'record_matched',    -- attached to this subject by a matching process
+    'human_reviewed'     -- a person looked at it and affirmed it
+);
+
+-- Whether an entity appears in a given registry. 'absent' is a positive
+-- finding, not a null: the FBI registry is a UCR-PARTICIPATION registry, not
+-- the NCIC ORI universe. Puerto Rico returns 1 agency. "Not in the registry"
+-- must never be read as "does not exist", and must never silently become the
+-- denominator of a coverage number.
+create type public.registry_presence as enum (
+    'present',
+    'absent',
+    'not_applicable',
+    'unknown'
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. Provenance spine
+-- ---------------------------------------------------------------------------
+
+create table public.source (
+    source_id text primary key,
+    slug text not null unique,
+    name text not null,
+    publisher text not null,
+    access_basis public.source_access_basis not null,
+    terms_status public.source_terms_status not null default 'unreviewed',
+    terms_url text,
+    terms_reviewed_at timestamp with time zone,
+    terms_reviewed_by text,
+    notes text,
+    created_at timestamp with time zone not null default timezone('utc'::text, now()),
+    updated_at timestamp with time zone not null default timezone('utc'::text, now()),
+
+    -- A cleared source must record who cleared it and when. Prevents
+    -- 'cleared' from being set as a convenience default.
+    constraint source_cleared_requires_review check (
+        terms_status <> 'cleared'
+        or (terms_reviewed_at is not null and terms_reviewed_by is not null)
+    )
+);
+
+comment on table public.source is
+'A dataset or records channel we are permitted to ingest from. INS-14 owns terms_status; a source that is not cleared cannot back a published claim.';
+
+-- One row per pull. Re-running a loader produces a NEW retrieval, never an
+-- update -- that is what makes "re-pull and diff" possible and what makes a
+-- retrieval date meaningful.
+create table public.source_retrieval (
+    retrieval_id text primary key,
+    source_id text not null references public.source (source_id) on delete restrict,
+    retrieved_at timestamp with time zone not null,
+    source_url text,
+    records_request_id text,
+    request_detail text,
+    content_hash text not null,
+    artifact_uri text,
+    created_at timestamp with time zone not null default timezone('utc'::text, now()),
+
+    -- The instruction is "source URL OR records-request identifier". This is
+    -- that requirement expressed as a constraint rather than a code review.
+    constraint source_retrieval_locator_required check (
+        source_url is not null or records_request_id is not null
+    ),
+    constraint source_retrieval_not_future check (
+        retrieved_at <= timezone('utc'::text, now()) + interval '1 hour'
+    )
+);
+
+comment on table public.source_retrieval is
+'One immutable row per pull of a source. Never updated in place; a re-pull is a new row. Supplies the retrieval date and the URL/records-request locator half of every citation.';
+
+create index source_retrieval_source_idx
+on public.source_retrieval (source_id, retrieved_at desc);
+
+-- Retrievals are append-only. A mutable retrieval date is a falsifiable
+-- citation.
+create or replace function public.reject_source_retrieval_mutation()
+returns trigger
+language plpgsql
+as $$
+begin
+    raise exception
+        'source_retrieval is append-only: attempted % on retrieval_id=%',
+        tg_op, coalesce(old.retrieval_id, new.retrieval_id)
+        using errcode = 'restrict_violation';
+end;
+$$;
+
+create trigger source_retrieval_append_only
+before update or delete on public.source_retrieval
+for each row execute function public.reject_source_retrieval_mutation();
+
+-- ---------------------------------------------------------------------------
+-- 3. Claim -- the only place a displayable value may live
+-- ---------------------------------------------------------------------------
+
+-- Predicates are registered, not free text. An unregistered predicate cannot
+-- be written, so a new displayable field cannot appear on a page without
+-- someone declaring its datatype and whether it is publishable at all.
+create table public.claim_predicate (
+    predicate text primary key,
+    subject_type text not null,
+    datatype text not null check (datatype in ('text', 'number', 'date', 'boolean')),
+    description text not null,
+    -- Some fields are ingested for internal use and must never render even
+    -- when cited. `agency_type_name` is the live example: it is internally
+    -- inconsistent across states (FBI returns 148 'State Police' agencies for
+    -- California, 1 for Texas), so it may drive grouping but must not be the
+    -- subtitle on a public page until a second source corroborates it.
+    renderable boolean not null default true,
+    -- Corroboration gate: how many INDEPENDENT sources must assert this
+    -- predicate before any claim on it may be published.
+    min_independent_sources integer not null default 1
+        check (min_independent_sources >= 1),
+    created_at timestamp with time zone not null default timezone('utc'::text, now())
+);
+
+comment on table public.claim_predicate is
+'Registry of displayable fields. Adding a field to a public page requires adding a row here, which is a reviewable schema change rather than a template edit.';
+
+create table public.claim (
+    claim_id text primary key,
+
+    subject_type text not null,
+    subject_id text not null,
+    predicate text not null references public.claim_predicate (predicate) on delete restrict,
+
+    -- Exactly one typed value column is populated, matching the predicate's
+    -- declared datatype -- or value_absent is true.
+    value_text text,
+    value_number numeric,
+    value_date date,
+    value_boolean boolean,
+
+    -- A source affirmatively telling us it does not know. This is NOT the same
+    -- as us not having asked. 39% of Texas federal-registry rows (686/1,754)
+    -- and 27% of California rows (237/867) have null lat/lon. That null is a
+    -- fact about the source and it renders as "not recorded by <source>",
+    -- with a citation, and is never silently backfilled.
+    value_absent boolean not null default false,
+
+    -- The invariant. A claim cannot be inserted without a retrieval, and a
+    -- retrieval cannot exist without a source, a date, and a locator.
+    retrieval_id text not null references public.source_retrieval (retrieval_id) on delete restrict,
+
+    -- Source-local identity for this record, so a claim can be traced back to
+    -- the exact row in the exact snapshot it came from.
+    source_record_key text not null,
+
+    confidence numeric not null check (confidence > 0 and confidence <= 1),
+    confidence_basis public.confidence_basis not null,
+
+    publication_status public.publication_status not null default 'staged',
+
+    -- Corrections supersede; they do not overwrite. The prior claim and its
+    -- citation stay readable for audit.
+    superseded_by_claim_id text references public.claim (claim_id) on delete restrict,
+
+    created_at timestamp with time zone not null default timezone('utc'::text, now()),
+    updated_at timestamp with time zone not null default timezone('utc'::text, now()),
+
+    constraint claim_exactly_one_value check (
+        case when value_absent then
+            (value_text is null and value_number is null
+             and value_date is null and value_boolean is null)
+        else
+            (num_nonnulls(value_text, value_number, value_date, value_boolean) = 1)
+        end
+    ),
+    constraint claim_not_self_superseding check (
+        superseded_by_claim_id is null or superseded_by_claim_id <> claim_id
+    )
+);
+
+comment on table public.claim is
+'Every value that can appear on a public page. retrieval_id is NOT NULL: an uncited claim cannot be represented in this schema.';
+
+create index claim_subject_idx
+on public.claim (subject_type, subject_id, predicate);
+
+create index claim_live_subject_idx
+on public.claim (subject_type, subject_id)
+where superseded_by_claim_id is null and publication_status = 'published';
+
+create index claim_retrieval_idx on public.claim (retrieval_id);
+create index claim_predicate_idx on public.claim (predicate);
+
+-- The typed value column must match the predicate's declared datatype.
+-- Cross-row check, so it is a trigger rather than a CHECK constraint.
+create or replace function public.enforce_claim_datatype()
+returns trigger
+language plpgsql
+as $$
+declare
+    declared_datatype text;
+    declared_subject_type text;
+begin
+    select datatype, subject_type
+    into declared_datatype, declared_subject_type
+    from public.claim_predicate
+    where predicate = new.predicate;
+
+    if declared_subject_type <> new.subject_type then
+        raise exception
+            'predicate % is declared for subject_type %, not %',
+            new.predicate, declared_subject_type, new.subject_type
+            using errcode = 'check_violation';
+    end if;
+
+    if new.value_absent then
+        return new;
+    end if;
+
+    if (declared_datatype = 'text' and new.value_text is null)
+        or (declared_datatype = 'number' and new.value_number is null)
+        or (declared_datatype = 'date' and new.value_date is null)
+        or (declared_datatype = 'boolean' and new.value_boolean is null)
+    then
+        raise exception
+            'predicate % is declared as % and requires value_%',
+            new.predicate, declared_datatype, declared_datatype
+            using errcode = 'check_violation';
+    end if;
+
+    return new;
+end;
+$$;
+
+create trigger claim_datatype_check
+before insert or update on public.claim
+for each row execute function public.enforce_claim_datatype();
+
+-- A claim may not be published if its predicate is not renderable, if its
+-- source is not terms-cleared, or if it has not met its corroboration
+-- threshold. Publication is refused rather than silently downgraded.
+create or replace function public.enforce_claim_publishable()
+returns trigger
+language plpgsql
+as $$
+declare
+    is_renderable boolean;
+    required_sources integer;
+    distinct_sources integer;
+    terms public.source_terms_status;
+begin
+    if new.publication_status <> 'published' then
+        return new;
+    end if;
+
+    select cp.renderable, cp.min_independent_sources
+    into is_renderable, required_sources
+    from public.claim_predicate cp
+    where cp.predicate = new.predicate;
+
+    if not is_renderable then
+        raise exception
+            'predicate % is not renderable and cannot be published',
+            new.predicate
+            using errcode = 'check_violation';
+    end if;
+
+    select s.terms_status into terms
+    from public.source_retrieval r
+    join public.source s on s.source_id = r.source_id
+    where r.retrieval_id = new.retrieval_id;
+
+    if terms <> 'cleared' then
+        raise exception
+            'claim %: backing source has terms_status=% and cannot be published',
+            new.claim_id, terms
+            using errcode = 'check_violation';
+    end if;
+
+    if required_sources > 1 then
+        select count(distinct r.source_id) into distinct_sources
+        from public.claim c
+        join public.source_retrieval r on r.retrieval_id = c.retrieval_id
+        where c.subject_type = new.subject_type
+          and c.subject_id = new.subject_id
+          and c.predicate = new.predicate
+          and c.superseded_by_claim_id is null
+          and (c.claim_id <> new.claim_id);
+
+        -- include this claim's own source
+        select distinct_sources + 1 into distinct_sources
+        where not exists (
+            select 1
+            from public.claim c
+            join public.source_retrieval r on r.retrieval_id = c.retrieval_id
+            join public.source_retrieval nr on nr.retrieval_id = new.retrieval_id
+            where c.claim_id <> new.claim_id
+              and c.subject_type = new.subject_type
+              and c.subject_id = new.subject_id
+              and c.predicate = new.predicate
+              and c.superseded_by_claim_id is null
+              and r.source_id = nr.source_id
+        );
+
+        if coalesce(distinct_sources, 1) < required_sources then
+            raise exception
+                'predicate % requires % independent sources; % present',
+                new.predicate, required_sources, coalesce(distinct_sources, 1)
+                using errcode = 'check_violation';
+        end if;
+    end if;
+
+    return new;
+end;
+$$;
+
+create trigger claim_publishable_check
+before insert or update on public.claim
+for each row execute function public.enforce_claim_publishable();
+
+-- ---------------------------------------------------------------------------
+-- 4. Publication audit trail and subject-level suppression
+-- ---------------------------------------------------------------------------
+
+-- Whole-subject suppression: a takedown, a legal hold, or the personnel
+-- publication gate. Overrides claim-level status. Built before we need it.
+create table public.subject_suppression (
+    suppression_id text primary key,
+    subject_type text not null,
+    subject_id text not null,
+    reason_code text not null check (reason_code in (
+        'personnel_publication_gate',
+        'takedown_request',
+        'legal_hold',
+        'data_subject_request',
+        'accuracy_dispute',
+        'source_withdrawn',
+        'sealed_or_expunged_suspected'
+    )),
+    reason_note text,
+    requested_by text,
+    applied_by text not null,
+    applied_at timestamp with time zone not null default timezone('utc'::text, now()),
+    lifted_by text,
+    lifted_at timestamp with time zone,
+    lift_note text,
+
+    constraint subject_suppression_lift_complete check (
+        (lifted_at is null and lifted_by is null)
+        or (lifted_at is not null and lifted_by is not null)
+    )
+);
+
+comment on table public.subject_suppression is
+'Fast, auditable suppression of an entire subject. An active row removes the subject from every render view regardless of claim status.';
+
+create unique index subject_suppression_active_idx
+on public.subject_suppression (subject_type, subject_id)
+where lifted_at is null;
+
+create table public.publication_event (
+    event_id text primary key,
+    subject_type text not null,
+    subject_id text not null,
+    claim_id text references public.claim (claim_id) on delete set null,
+    from_status public.publication_status,
+    to_status public.publication_status not null,
+    reason_code text,
+    reason_note text,
+    actor text not null,
+    occurred_at timestamp with time zone not null default timezone('utc'::text, now())
+);
+
+comment on table public.publication_event is
+'Append-only audit trail of every publication-status transition. Written by trigger, so a status change cannot happen without a recorded event.';
+
+create index publication_event_subject_idx
+on public.publication_event (subject_type, subject_id, occurred_at desc);
+
+create index publication_event_claim_idx
+on public.publication_event (claim_id, occurred_at desc);
+
+-- Every status transition writes an event. Not optional, not a code path.
+-- The actor comes from a session GUC so the audit trail names a human or a
+-- named automated process rather than a database role.
+create or replace function public.record_publication_event()
+returns trigger
+language plpgsql
+as $$
+declare
+    acting text;
+begin
+    if tg_op = 'UPDATE'
+        and old.publication_status is not distinct from new.publication_status
+    then
+        return new;
+    end if;
+
+    acting := coalesce(
+        nullif(current_setting('intake.actor', true), ''),
+        'unattributed:' || session_user
+    );
+
+    insert into public.publication_event (
+        event_id, subject_type, subject_id, claim_id,
+        from_status, to_status, reason_code, reason_note, actor
+    )
+    values (
+        'pev_' || encode(gen_random_bytes(12), 'hex'),
+        new.subject_type,
+        new.subject_id,
+        new.claim_id,
+        case when tg_op = 'UPDATE' then old.publication_status else null end,
+        new.publication_status,
+        nullif(current_setting('intake.reason_code', true), ''),
+        nullif(current_setting('intake.reason_note', true), ''),
+        acting
+    );
+
+    return new;
+end;
+$$;
+
+comment on function public.record_publication_event() is
+'Audit events use a generated non-durable event_id; publication_event is an append-only log, not a durable entity, so the intake ID policy does not apply.';
+
+create trigger claim_publication_audit
+after insert or update of publication_status on public.claim
+for each row execute function public.record_publication_event();
+
+create or replace function public.reject_publication_event_mutation()
+returns trigger
+language plpgsql
+as $$
+begin
+    raise exception 'publication_event is append-only: attempted %', tg_op
+        using errcode = 'restrict_violation';
+end;
+$$;
+
+create trigger publication_event_append_only
+before update or delete on public.publication_event
+for each row execute function public.reject_publication_event_mutation();
+
+-- ---------------------------------------------------------------------------
+-- 5. Canonical agency identity -- ORI, and the entity layer above it
+-- ---------------------------------------------------------------------------
+
+-- The department a member of the public would name: "California Highway
+-- Patrol". The FBI registry returns 148 rows typed 'State Police' for
+-- California, each holding its own ORI, because ORI is a REPORTING-UNIT key,
+-- not a department key. Without this layer CHP renders as 148 separate police
+-- departments. Agency-side entity resolution is therefore a first-class
+-- problem, not just a personnel-side one.
+create table public.agency_entity (
+    agency_entity_id text primary key,
+    state text not null,
+    canonical_name text not null,
+    entity_kind text not null check (entity_kind in (
+        'municipal_police', 'county_sheriff', 'state_police', 'state_agency',
+        'federal_agency', 'tribal', 'university_campus', 'school_district',
+        'transit', 'airport', 'special_jurisdiction', 'corrections',
+        'prosecutor', 'other', 'unclassified'
+    )),
+    created_at timestamp with time zone not null default timezone('utc'::text, now()),
+    updated_at timestamp with time zone not null default timezone('utc'::text, now())
+);
+
+comment on table public.agency_entity is
+'The department-level entity above the ORI reporting unit. One CHP, not 148. canonical_name and entity_kind are internal grouping keys; the public-facing name is a claim.';
+
+-- An agency (reporting unit) belongs to at most one entity. Membership is
+-- itself evidence-backed and confidence-scored.
+create table public.agency_entity_member (
+    membership_id text primary key,
+    agency_entity_id text not null references public.agency_entity (agency_entity_id) on delete restrict,
+    agency_id text not null references public.agency (id) on delete cascade,
+    confidence numeric not null check (confidence > 0 and confidence <= 1),
+    method text not null check (method in (
+        'shared_ori_prefix', 'name_pattern', 'source_asserted', 'manual_review'
+    )),
+    evidence jsonb not null,
+    reviewed_by text,
+    reviewed_at timestamp with time zone,
+    created_at timestamp with time zone not null default timezone('utc'::text, now()),
+
+    constraint agency_entity_member_unique unique (agency_id)
+);
+
+create index agency_entity_member_entity_idx
+on public.agency_entity_member (agency_entity_id);
+
+-- ORI assignment. The FORM is recorded explicitly, because federal datasets
+-- mix 7-character and 9-character ORIs and an unlabeled `ori` column silently
+-- fails to join across them. A silent join failure here means a page about
+-- the wrong department.
+create table public.agency_ori (
+    agency_ori_id text primary key,
+    agency_id text not null references public.agency (id) on delete cascade,
+    ori text not null,
+    ori_form text not null check (ori_form in ('ori7', 'ori9')),
+
+    -- Derived 7-character bridge key for cross-form joins. Generated, so it
+    -- cannot drift from `ori`, and explicitly derived so nobody mistakes it
+    -- for a source-asserted identifier.
+    ori7 text generated always as (upper(substring(ori from 1 for 7))) stored,
+
+    is_primary boolean not null default false,
+    retrieval_id text not null references public.source_retrieval (retrieval_id) on delete restrict,
+    confidence numeric not null check (confidence > 0 and confidence <= 1),
+    created_at timestamp with time zone not null default timezone('utc'::text, now()),
+
+    constraint agency_ori_form_length check (
+        (ori_form = 'ori7' and length(ori) = 7)
+        or (ori_form = 'ori9' and length(ori) = 9)
+    ),
+    constraint agency_ori_shape check (ori ~ '^[A-Z]{2}[A-Z0-9]{5,7}$'),
+    constraint agency_ori_unique unique (agency_id, ori, ori_form)
+);
+
+comment on column public.agency_ori.ori7 is
+'Derived 7-character bridge key. Two ORIs sharing an ori7 are candidates for the same reporting unit across dataset generations -- a candidate, never an automatic merge.';
+
+create unique index agency_ori_one_primary_idx
+on public.agency_ori (agency_id)
+where is_primary;
+
+create index agency_ori_ori7_idx on public.agency_ori (ori7);
+create index agency_ori_lookup_idx on public.agency_ori (ori);
+
+-- Reviewed conflict queue. Nothing auto-resolves.
+create table public.ori_conflict (
+    conflict_id text primary key,
+    ori7 text not null,
+    conflict_type text not null check (conflict_type in (
+        'same_ori_multiple_agencies',
+        'same_ori7_different_forms',
+        'agency_multiple_primary_candidates',
+        'registry_name_mismatch',
+        'absent_from_registry'
+    )),
+    detected_at timestamp with time zone not null default timezone('utc'::text, now()),
+    status text not null default 'open' check (status in ('open', 'resolved', 'wont_fix')),
+    evidence jsonb not null,
+    resolution_note text,
+    resolved_by text,
+    resolved_at timestamp with time zone,
+
+    constraint ori_conflict_resolution_complete check (
+        status = 'open'
+        or (resolved_by is not null and resolved_at is not null and resolution_note is not null)
+    )
+);
+
+comment on table public.ori_conflict is
+'Reviewed conflict queue for ORI inconsistencies. Populated by trigger on detection. An open conflict suppresses the affected agencies from render -- accuracy over coverage.';
+
+create unique index ori_conflict_open_idx
+on public.ori_conflict (ori7, conflict_type)
+where status = 'open';
+
+-- Detect ORI collisions on write and open a conflict rather than resolving
+-- them. Two different agencies claiming the same ORI means at least one page
+-- is about the wrong department.
+create or replace function public.detect_ori_conflict()
+returns trigger
+language plpgsql
+as $$
+declare
+    colliding_agencies integer;
+    form_variants integer;
+begin
+    select count(distinct agency_id) into colliding_agencies
+    from public.agency_ori
+    where ori7 = upper(substring(new.ori from 1 for 7));
+
+    if colliding_agencies > 1 then
+        insert into public.ori_conflict (conflict_id, ori7, conflict_type, evidence)
+        values (
+            'oric_' || encode(gen_random_bytes(12), 'hex'),
+            upper(substring(new.ori from 1 for 7)),
+            'same_ori_multiple_agencies',
+            jsonb_build_object(
+                'agency_ids', (
+                    select jsonb_agg(distinct agency_id)
+                    from public.agency_ori
+                    where ori7 = upper(substring(new.ori from 1 for 7))
+                ),
+                'triggering_agency_ori_id', new.agency_ori_id
+            )
+        )
+        on conflict do nothing;
+    end if;
+
+    select count(distinct ori_form) into form_variants
+    from public.agency_ori
+    where ori7 = upper(substring(new.ori from 1 for 7));
+
+    if form_variants > 1 then
+        insert into public.ori_conflict (conflict_id, ori7, conflict_type, evidence)
+        values (
+            'oric_' || encode(gen_random_bytes(12), 'hex'),
+            upper(substring(new.ori from 1 for 7)),
+            'same_ori7_different_forms',
+            jsonb_build_object('triggering_agency_ori_id', new.agency_ori_id)
+        )
+        on conflict do nothing;
+    end if;
+
+    return new;
+end;
+$$;
+
+-- The `on conflict do nothing` above is deduplication of an open queue entry,
+-- not suppression of bad data: the conflict row already exists and is open.
+create trigger agency_ori_conflict_detect
+after insert on public.agency_ori
+for each row execute function public.detect_ori_conflict();
+
+-- "Absent from the registry" is a recorded finding, not a missing row.
+create table public.agency_registry_presence (
+    presence_id text primary key,
+    agency_id text not null references public.agency (id) on delete cascade,
+    source_id text not null references public.source (source_id) on delete restrict,
+    presence public.registry_presence not null,
+    retrieval_id text not null references public.source_retrieval (retrieval_id) on delete restrict,
+    note text,
+    created_at timestamp with time zone not null default timezone('utc'::text, now()),
+
+    constraint agency_registry_presence_unique unique (agency_id, source_id, retrieval_id)
+);
+
+comment on table public.agency_registry_presence is
+'Explicit presence/absence of an agency in a given registry as of a given retrieval. INS-7 coverage denominators must be computed from this, never from a registry row count.';
+
+-- ---------------------------------------------------------------------------
+-- 6. Personnel identity -- confidence-scored links, never hard merges
+-- ---------------------------------------------------------------------------
+
+-- A person row is an identity HYPOTHESIS with no attributes. Names are claims.
+-- This is deliberate: it means there is no `person.first_name` column that
+-- could ever be rendered without a citation.
+create table public.person (
+    person_id text primary key,
+    -- Link back to the legacy officers row during migration, so the existing
+    -- corpus can be attached without being rewritten.
+    legacy_officer_id text references public.officers (id) on delete set null,
+    created_at timestamp with time zone not null default timezone('utc'::text, now()),
+    updated_at timestamp with time zone not null default timezone('utc'::text, now())
+);
+
+comment on table public.person is
+'An identity hypothesis. Intentionally attribute-free: every displayable fact about a person is a claim, so there is no column here that could render uncited.';
+
+create unique index person_legacy_officer_idx
+on public.person (legacy_officer_id)
+where legacy_officer_id is not null;
+
+-- Name variants. The same human appears under different names across sources
+-- and across a career. Every variant keeps its own citation.
+create table public.person_name_variant (
+    name_variant_id text primary key,
+    person_id text not null references public.person (person_id) on delete cascade,
+    full_name text not null,
+    first_name text,
+    middle_name text,
+    last_name text,
+    suffix text,
+    -- Blocking key for candidate generation. Derived, never displayed.
+    normalized_key text not null,
+    retrieval_id text not null references public.source_retrieval (retrieval_id) on delete restrict,
+    source_record_key text not null,
+    confidence numeric not null check (confidence > 0 and confidence <= 1),
+    created_at timestamp with time zone not null default timezone('utc'::text, now())
+);
+
+create index person_name_variant_person_idx
+on public.person_name_variant (person_id);
+
+create index person_name_variant_blocking_idx
+on public.person_name_variant (normalized_key);
+
+-- Employment interval. Its EXISTENCE is a displayable assertion, so it carries
+-- a retrieval. Its attributes (rank, badge number, dates) are claims on
+-- subject_type='employment'.
+create table public.employment_period (
+    employment_id text primary key,
+    person_id text not null references public.person (person_id) on delete cascade,
+    agency_id text not null references public.agency (id) on delete restrict,
+    retrieval_id text not null references public.source_retrieval (retrieval_id) on delete restrict,
+    source_record_key text not null,
+    confidence numeric not null check (confidence > 0 and confidence <= 1),
+    publication_status public.publication_status not null default 'staged',
+    created_at timestamp with time zone not null default timezone('utc'::text, now()),
+    updated_at timestamp with time zone not null default timezone('utc'::text, now())
+);
+
+comment on table public.employment_period is
+'Person-at-agency assertion. Dates, rank and badge number are claims on subject_type=''employment'', not columns here.';
+
+create index employment_period_person_idx on public.employment_period (person_id);
+create index employment_period_agency_idx on public.employment_period (agency_id);
+
+-- Identity resolution. Two person rows are LINKED, never merged. A link is
+-- reversible; a merge is not, and an incorrect merge attributes one officer's
+-- misconduct to a different human being.
+create table public.person_identity_link (
+    link_id text primary key,
+    person_id_a text not null references public.person (person_id) on delete cascade,
+    person_id_b text not null references public.person (person_id) on delete cascade,
+
+    -- 'distinct_person' is as valuable as 'same_person': it records a reviewed
+    -- negative so the same false candidate is not re-proposed every run.
+    assertion text not null check (assertion in ('same_person', 'possible_same_person', 'distinct_person')),
+    confidence numeric not null check (confidence > 0 and confidence <= 1),
+    method text not null check (method in (
+        'state_certification_number',
+        'exact_name_and_dob',
+        'name_and_agency_overlap',
+        'name_and_badge_overlap',
+        'probabilistic_score',
+        'manual_review'
+    )),
+    evidence jsonb not null,
+    status text not null default 'proposed' check (status in ('proposed', 'accepted', 'rejected')),
+    reviewed_by text,
+    reviewed_at timestamp with time zone,
+    created_at timestamp with time zone not null default timezone('utc'::text, now()),
+
+    -- Canonical ordering makes the pair unique in one direction only.
+    constraint person_identity_link_ordered check (person_id_a < person_id_b),
+    constraint person_identity_link_unique unique (person_id_a, person_id_b, method),
+    constraint person_identity_link_review_complete check (
+        status = 'proposed'
+        or (reviewed_by is not null and reviewed_at is not null)
+    ),
+    -- Automated methods may not self-accept a same_person link. Merging two
+    -- officer careers is a human-reviewed decision.
+    constraint person_identity_link_same_person_needs_review check (
+        not (assertion = 'same_person' and status = 'accepted' and method <> 'manual_review'
+             and method <> 'state_certification_number')
+    )
+);
+
+comment on table public.person_identity_link is
+'Confidence-scored identity assertions between person rows. Never a merge: no row is rewritten, and any link can be reversed without data loss.';
+
+create index person_identity_link_a_idx on public.person_identity_link (person_id_a, status);
+create index person_identity_link_b_idx on public.person_identity_link (person_id_b, status);
+
+-- ---------------------------------------------------------------------------
+-- 7. The render surface
+-- ---------------------------------------------------------------------------
+
+create schema render;
+
+comment on schema render is
+'The only schema the page-build role may read. Every column that carries a value carries its citation in the same column.';
+
+-- Assemble value + citation into one indivisible jsonb. A renderer cannot
+-- select the value and drop the source, because they are the same column.
+create or replace function render.cite(
+    p_value jsonb,
+    p_absent boolean,
+    p_source_slug text,
+    p_source_name text,
+    p_publisher text,
+    p_retrieved_at timestamp with time zone,
+    p_source_url text,
+    p_records_request_id text,
+    p_confidence numeric,
+    p_confidence_basis text
+)
+returns jsonb
+language sql
+immutable
+as $$
+    select jsonb_build_object(
+        'value', case when p_absent then null else p_value end,
+        'absent', p_absent,
+        'citation', jsonb_build_object(
+            'source', p_source_slug,
+            'sourceName', p_source_name,
+            'publisher', p_publisher,
+            'retrievedAt', p_retrieved_at,
+            'locator', coalesce(p_source_url, 'records-request:' || p_records_request_id),
+            'locatorType', case when p_source_url is not null then 'url' else 'records_request' end,
+            'confidence', p_confidence,
+            'confidenceBasis', p_confidence_basis
+        )
+    );
+$$;
+
+-- The single published-claim view. Note what is NOT here: value_text,
+-- value_number, value_date, value_boolean. There is no bare value column to
+-- select.
+create view render.published_claim as
+select
+    c.subject_type,
+    c.subject_id,
+    c.predicate,
+    render.cite(
+        case
+            when c.value_text is not null then to_jsonb(c.value_text)
+            when c.value_number is not null then to_jsonb(c.value_number)
+            when c.value_date is not null then to_jsonb(c.value_date)
+            when c.value_boolean is not null then to_jsonb(c.value_boolean)
+            else null
+        end,
+        c.value_absent,
+        s.slug, s.name, s.publisher,
+        r.retrieved_at, r.source_url, r.records_request_id,
+        c.confidence, c.confidence_basis::text
+    ) as cited_value
+from public.claim c
+    inner join public.source_retrieval r on r.retrieval_id = c.retrieval_id
+    inner join public.source s on s.source_id = r.source_id
+    inner join public.claim_predicate cp on cp.predicate = c.predicate
+where c.publication_status = 'published'
+    and c.superseded_by_claim_id is null
+    and cp.renderable
+    and s.terms_status = 'cleared'
+    and not exists (
+        select 1 from public.subject_suppression sup
+        where sup.subject_type = c.subject_type
+            and sup.subject_id = c.subject_id
+            and sup.lifted_at is null
+    );
+
+comment on view render.published_claim is
+'The entire public read surface for field values. INNER JOINs to retrieval and source make an uncited row unrepresentable in the result set.';
+
+-- Agency identity for URL construction. ORI is an identifier, not a claim
+-- about a person, but it is still suppressed while an ORI conflict is open --
+-- an unresolved ORI collision means we may be about to publish a page about
+-- the wrong department.
+create view render.published_agency as
+select
+    a.id as agency_id,
+    aem.agency_entity_id,
+    ao.ori,
+    ao.ori_form
+from public.agency a
+    inner join public.agency_ori ao on ao.agency_id = a.id and ao.is_primary
+    left join public.agency_entity_member aem on aem.agency_id = a.id
+where not exists (
+    select 1 from public.subject_suppression sup
+    where sup.subject_type = 'agency' and sup.subject_id = a.id and sup.lifted_at is null
+)
+and not exists (
+    select 1 from public.ori_conflict oc
+    where oc.ori7 = ao.ori7 and oc.status = 'open'
+);
+
+-- Personnel render surface. Gated at the schema level, not the template level:
+-- until the Data Integrity & Publication Risk Reviewer clears the gate, this
+-- view is defined to return zero rows and the page_renderer role is not
+-- granted SELECT on it at all.
+--
+-- Two independent locks. Removing one does not open the gate.
+create view render.published_person as
+select
+    p.person_id,
+    e.employment_id,
+    e.agency_id
+from public.person p
+    inner join public.employment_period e on e.person_id = p.person_id
+where e.publication_status = 'published'
+    and not exists (
+        select 1 from public.subject_suppression sup
+        where sup.subject_type = 'person' and sup.subject_id = p.person_id and sup.lifted_at is null
+    )
+    -- Lock 1: hard gate. Removing this line is a visible, reviewable schema
+    -- migration, not a config flag someone can flip.
+    and false;
+
+comment on view render.published_person is
+'PERSONNEL PUBLICATION GATE. Hard-coded to return zero rows AND not granted to page_renderer. Opening it requires a migration plus a grant, both reviewable, and requires Data Integrity & Publication Risk Reviewer clearance per INS-11.';
+
+-- ---------------------------------------------------------------------------
+-- 8. Least-privilege render role
+-- ---------------------------------------------------------------------------
+
+-- The page build connects as this role. It has SELECT on the render views and
+-- on nothing else -- so "read a base table and skip the citation" is not a
+-- discipline problem, it is a permission denied.
+do $$
+begin
+    if not exists (select 1 from pg_roles where rolname = 'page_renderer') then
+        create role page_renderer nologin;
+    end if;
+end;
+$$;
+
+revoke all on schema public from page_renderer;
+revoke all on all tables in schema public from page_renderer;
+revoke all on all sequences in schema public from page_renderer;
+revoke all on all functions in schema public from page_renderer;
+
+grant usage on schema render to page_renderer;
+
+-- The allowlist. Deliberately not `grant select on all tables in schema
+-- render` -- each grant is an explicit, greppable, reviewable line, and
+-- render.published_person is conspicuously absent.
+grant select on render.published_claim to page_renderer;
+grant select on render.published_agency to page_renderer;
+
+-- The views are owned by the migration role and read base tables through
+-- their owner's rights, so page_renderer never needs USAGE on public.
+alter view render.published_claim set (security_invoker = off);
+alter view render.published_agency set (security_invoker = off);
+alter view render.published_person set (security_invoker = off);
+
+-- Future objects in `render` are NOT granted automatically. A new render view
+-- is unreadable until someone writes an explicit grant.
+alter default privileges in schema render revoke all on tables from page_renderer;
+
+-- ---------------------------------------------------------------------------
+-- 9. Self-check the invariant holds
+-- ---------------------------------------------------------------------------
+
+-- Callable in CI and after every migration. Returns violations; empty result
+-- means the invariant is intact. This is what stops a later migration from
+-- quietly granting the renderer access to a base table.
+create or replace function public.assert_provenance_invariant()
+returns table (violation text, detail text)
+language sql
+stable
+as $$
+    -- 1. page_renderer must hold no privilege on any table outside `render`.
+    select
+        'renderer_reads_base_table'::text,
+        (table_schema || '.' || table_name || ' [' || privilege_type || ']')::text
+    from information_schema.table_privileges
+    where grantee = 'page_renderer'
+        and table_schema <> 'render'
+
+    union all
+
+    -- 2. page_renderer must hold no privilege on a render object outside the
+    --    reviewed allowlist. Catches a future `grant select on all tables`.
+    select
+        'renderer_grant_outside_allowlist'::text,
+        (table_name || ' [' || privilege_type || ']')::text
+    from information_schema.table_privileges
+    where grantee = 'page_renderer'
+        and table_schema = 'render'
+        and table_name not in ('published_claim', 'published_agency')
+
+    union all
+
+    -- 3. The personnel gate must remain closed.
+    select
+        'personnel_gate_open'::text,
+        'page_renderer holds ' || privilege_type || ' on render.published_person'
+    from information_schema.table_privileges
+    where grantee = 'page_renderer'
+        and table_schema = 'render'
+        and table_name = 'published_person'
+
+    union all
+
+    -- 4. No render view may expose a bare value column.
+    select
+        'render_view_exposes_bare_value'::text,
+        (table_name || '.' || column_name)::text
+    from information_schema.columns
+    where table_schema = 'render'
+        and column_name in ('value_text', 'value_number', 'value_date', 'value_boolean');
+$$;
+
+comment on function public.assert_provenance_invariant() is
+'Returns zero rows when the provenance invariant is intact. Run in CI after migrations; a non-empty result fails the build.';
+
+commit;

--- a/test/schema/provenance-invariant.test.ts
+++ b/test/schema/provenance-invariant.test.ts
@@ -10,9 +10,27 @@
  * TEST_DATABASE_URL must be a fully-qualified URL with a host, because the
  * render-role tests rewrite its credentials.
  *
- *   createdb intake_schema_test
- *   TEST_DATABASE_URL=postgres://localhost:5432/intake_schema_test \
- *     npm run test:vitest -- test/schema
+ * Two modes, chosen by whether the target database has the real upstream
+ * schema (detected via `agency.location_path_id`):
+ *
+ *   Real-schema mode (a `supabase db reset` database). The migration set is
+ *   already applied, so the suite runs against it as it stands -- against the
+ *   real `agency`/`officers` definitions, with Supabase's own roles and
+ *   default privileges present. It rebuilds nothing, clears only the rows it
+ *   created, and refuses to run if the database holds data it did not create.
+ *   This is the mode that proves the migration composes with the real schema.
+ *
+ *     npm run supabase:start && npm run supabase:reset
+ *     TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:54322/postgres \
+ *       npx vitest run test/schema
+ *
+ *   Fixture mode (a bare Postgres with no upstream schema, e.g. a host with no
+ *   PostGIS). `upstream-fixture.sql` stands in for the three upstream objects
+ *   the migration references and the schema is rebuilt in place.
+ *
+ *     createdb intake_schema_test
+ *     TEST_DATABASE_URL=postgres://localhost:5432/intake_schema_test \
+ *       npm run test:vitest -- test/schema
  */
 
 import { readFileSync } from "node:fs";
@@ -32,12 +50,43 @@ const FIXTURE_PATH = fileURLToPath(
   new URL("./upstream-fixture.sql", import.meta.url),
 );
 
+/**
+ * Every table the provenance migration creates, for the real-schema-mode
+ * reset. Truncating these is what makes the suite re-runnable there; it is
+ * guarded by the emptiness check in `beforeAll`, so it can only ever remove
+ * this suite's own leftovers.
+ */
+const PROVENANCE_TABLES = [
+  "person_identity_link",
+  "employment_period",
+  "person_name_variant",
+  "person",
+  "agency_registry_presence",
+  "ori_conflict",
+  "agency_ori",
+  "agency_entity_member",
+  "agency_entity",
+  "publication_event",
+  "subject_suppression",
+  "claim",
+  "claim_predicate",
+  "source_retrieval",
+  "source",
+];
+
 const RETRIEVAL = "ret_test_0001";
 const SOURCE = "src_test_0001";
 const AGENCY_A = "agency_test_a";
 const AGENCY_B = "agency_test_b";
+const LOCATION_PATH = "locpath_test_tx";
 
 let admin: Client;
+
+/** Connection string actually under test. */
+let testUrl: string;
+
+/** True when running against a real migrated (`supabase db reset`) database. */
+let realSchema = false;
 
 /** Run SQL and return the error message, or null if it unexpectedly succeeded. */
 async function rejects(sql: string, params: unknown[] = []): Promise<string> {
@@ -51,24 +100,81 @@ async function rejects(sql: string, params: unknown[] = []): Promise<string> {
 
 describe.skipIf(!DATABASE_URL)("provenance structural invariant", () => {
   beforeAll(async () => {
-    admin = new Client({ connectionString: DATABASE_URL });
-    await admin.connect();
+    // Decide the mode BEFORE touching anything. This check has to precede the
+    // schema drops below: dropping `public` first would guarantee `agency` is
+    // absent, so the fixture would always win and the suite would never
+    // exercise the real schema it claims to.
+    //
+    // The marker is `agency.location_path_id`, not the existence of `agency`.
+    // The fixture creates an `agency` too, so keying off the table would make
+    // the second fixture-mode run mistake its own leftovers for the real
+    // schema. Only the real migration set adds this column.
+    const bootstrap = new Client({ connectionString: DATABASE_URL });
+    await bootstrap.connect();
+    realSchema = (
+      await bootstrap.query(
+        `select exists (
+           select 1 from information_schema.columns
+           where table_schema = 'public'
+             and table_name = 'agency'
+             and column_name = 'location_path_id'
+         ) as present`,
+      )
+    ).rows[0].present as boolean;
 
-    // Start from a known-empty state so the suite is re-runnable.
-    await admin.query(`drop schema if exists render cascade`);
-    await admin.query(`drop schema if exists public cascade`);
-    await admin.query(`create schema public`);
-    await admin.query(`drop owned by page_renderer`).catch(() => {});
-    await admin.query(`drop role if exists page_renderer`).catch(() => {});
+    if (realSchema) {
+      // Real-schema mode: the target already has the full migration set
+      // applied by `supabase db reset`, including this migration. Use it as
+      // it stands -- that artifact, with Supabase's own roles and default
+      // privileges present, is exactly what we need to test. Do not rebuild
+      // the schema: replaying migrations into a blank database does not work
+      // (they reference Supabase bootstrap schemas such as `graphql` that
+      // `create database` does not provide), and dropping `public` here would
+      // destroy the developer's stack.
+      testUrl = DATABASE_URL!;
+      admin = bootstrap;
 
-    const agencyExists = await admin.query(
-      `select to_regclass('public.agency') is not null as present`,
-    );
-    if (!agencyExists.rows[0].present) {
+      // Refuse to touch a database with real data in it. A freshly reset
+      // database has no agencies; anything else is not a test database.
+      const strays = await admin.query(
+        `select count(*)::int as n from public.agency where id <> all($1::text[])`,
+        [[AGENCY_A, AGENCY_B]],
+      );
+      if (strays.rows[0].n > 0) {
+        throw new Error(
+          `refusing to run: public.agency holds ${strays.rows[0].n} row(s) this suite did not create. ` +
+            `Point TEST_DATABASE_URL at a freshly reset database (npm run supabase:reset).`,
+        );
+      }
+
+      // Re-runnable: clear this suite's leftovers from a previous run.
+      await admin.query(
+        `truncate table ${PROVENANCE_TABLES.map((t) => `public.${t}`).join(", ")} cascade`,
+      );
+      await admin.query(
+        `delete from public.agency where id = any($1::text[])`,
+        [[AGENCY_A, AGENCY_B]],
+      );
+      await admin.query(
+        `delete from public.location_path where location_path_id = $1`,
+        [LOCATION_PATH],
+      );
+    } else {
+      // Fixture mode: a bare Postgres with no upstream schema. Rebuild in
+      // place and stand in for the three objects the migration references.
+      testUrl = DATABASE_URL!;
+      admin = bootstrap;
+
+      // Start from a known-empty state so the suite is re-runnable.
+      await admin.query(`drop schema if exists render cascade`);
+      await admin.query(`drop schema if exists public cascade`);
+      await admin.query(`create schema public`);
+      await admin.query(`drop owned by page_renderer`).catch(() => {});
+      await admin.query(`drop role if exists page_renderer`).catch(() => {});
+
       await admin.query(readFileSync(FIXTURE_PATH, "utf8"));
+      await admin.query(readFileSync(MIGRATION_PATH, "utf8"));
     }
-
-    await admin.query(readFileSync(MIGRATION_PATH, "utf8"));
 
     // A cleared source and one retrieval, used by most tests below.
     await admin.query(
@@ -95,12 +201,32 @@ describe.skipIf(!DATABASE_URL)("provenance structural invariant", () => {
          ('agency.agency_type_name', 'agency', 'text',
           'Source classification; inconsistent across states, internal only', false)`,
     );
-    await admin.query(
-      `insert into public.agency (id, name, state) values
-         ($1, 'Test Police Department', 'TX'),
-         ($2, 'Other Police Department', 'TX')`,
-      [AGENCY_A, AGENCY_B],
-    );
+    if (realSchema) {
+      // The real `agency` carries two NOT NULL columns the fixture does not:
+      // `slug` and a restricted FK to `location_path`. Seeding them here is
+      // the difference between testing the real table and testing a stand-in.
+      await admin.query(
+        `insert into public.location_path
+           (location_path_id, path, level, state_or_territory_slug,
+            state_or_territory_name)
+         values ($1, '/tx', 'state', 'tx', 'Texas')
+         on conflict (location_path_id) do nothing`,
+        [LOCATION_PATH],
+      );
+      await admin.query(
+        `insert into public.agency (id, name, state, slug, location_path_id)
+         values ($1, 'Test Police Department', 'TX', 'test-police-department', $3),
+                ($2, 'Other Police Department', 'TX', 'other-police-department', $3)`,
+        [AGENCY_A, AGENCY_B, LOCATION_PATH],
+      );
+    } else {
+      await admin.query(
+        `insert into public.agency (id, name, state) values
+           ($1, 'Test Police Department', 'TX'),
+           ($2, 'Other Police Department', 'TX')`,
+        [AGENCY_A, AGENCY_B],
+      );
+    }
   });
 
   afterAll(async () => {
@@ -223,7 +349,7 @@ describe.skipIf(!DATABASE_URL)("provenance structural invariant", () => {
       // also supplied, so the credentials must be embedded in the URL. Getting
       // this wrong silently connects as the superuser and turns every
       // permission assertion below into a false pass.
-      const url = new URL(DATABASE_URL!);
+      const url = new URL(testUrl);
       url.username = "page_renderer";
       url.password = "test-only";
       renderer = new Client({ connectionString: url.toString() });

--- a/test/schema/provenance-invariant.test.ts
+++ b/test/schema/provenance-invariant.test.ts
@@ -1,0 +1,744 @@
+/**
+ * Demonstrated enforcement of the provenance invariant.
+ *
+ * These tests are the evidence for INS-5's "done when" clause. Each one tries
+ * to do the thing the invariant is supposed to make impossible and asserts
+ * that the database refuses.
+ *
+ * Requires a Postgres connection string in TEST_DATABASE_URL. The suite skips
+ * itself when that is absent so `npm test` stays green without a database.
+ * TEST_DATABASE_URL must be a fully-qualified URL with a host, because the
+ * render-role tests rewrite its credentials.
+ *
+ *   createdb intake_schema_test
+ *   TEST_DATABASE_URL=postgres://localhost:5432/intake_schema_test \
+ *     npm run test:vitest -- test/schema
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const DATABASE_URL = process.env.TEST_DATABASE_URL;
+
+const MIGRATION_PATH = fileURLToPath(
+  new URL(
+    "../../supabase/migrations/20260824170000_provenance_structural_invariant.sql",
+    import.meta.url,
+  ),
+);
+const FIXTURE_PATH = fileURLToPath(
+  new URL("./upstream-fixture.sql", import.meta.url),
+);
+
+const RETRIEVAL = "ret_test_0001";
+const SOURCE = "src_test_0001";
+const AGENCY_A = "agency_test_a";
+const AGENCY_B = "agency_test_b";
+
+let admin: Client;
+
+/** Run SQL and return the error message, or null if it unexpectedly succeeded. */
+async function rejects(sql: string, params: unknown[] = []): Promise<string> {
+  try {
+    await admin.query(sql, params);
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error(`expected statement to be rejected but it succeeded: ${sql}`);
+}
+
+describe.skipIf(!DATABASE_URL)("provenance structural invariant", () => {
+  beforeAll(async () => {
+    admin = new Client({ connectionString: DATABASE_URL });
+    await admin.connect();
+
+    // Start from a known-empty state so the suite is re-runnable.
+    await admin.query(`drop schema if exists render cascade`);
+    await admin.query(`drop schema if exists public cascade`);
+    await admin.query(`create schema public`);
+    await admin.query(`drop owned by page_renderer`).catch(() => {});
+    await admin.query(`drop role if exists page_renderer`).catch(() => {});
+
+    const agencyExists = await admin.query(
+      `select to_regclass('public.agency') is not null as present`,
+    );
+    if (!agencyExists.rows[0].present) {
+      await admin.query(readFileSync(FIXTURE_PATH, "utf8"));
+    }
+
+    await admin.query(readFileSync(MIGRATION_PATH, "utf8"));
+
+    // A cleared source and one retrieval, used by most tests below.
+    await admin.query(
+      `insert into public.source
+         (source_id, slug, name, publisher, access_basis, terms_status,
+          terms_reviewed_at, terms_reviewed_by)
+       values ($1, 'fbi-cde-agency-registry', 'FBI CDE Agency Registry',
+               'Federal Bureau of Investigation', 'public_api', 'cleared',
+               now(), 'founding-engineer')`,
+      [SOURCE],
+    );
+    await admin.query(
+      `insert into public.source_retrieval
+         (retrieval_id, source_id, retrieved_at, source_url, content_hash)
+       values ($1, $2, now(), 'https://api.usa.gov/crime/fbi/cde/agency', 'sha256:test')`,
+      [RETRIEVAL, SOURCE],
+    );
+    await admin.query(
+      `insert into public.claim_predicate
+         (predicate, subject_type, datatype, description, renderable)
+       values
+         ('agency.name', 'agency', 'text', 'Agency display name', true),
+         ('agency.latitude', 'agency', 'number', 'Latitude', true),
+         ('agency.agency_type_name', 'agency', 'text',
+          'Source classification; inconsistent across states, internal only', false)`,
+    );
+    await admin.query(
+      `insert into public.agency (id, name, state) values
+         ($1, 'Test Police Department', 'TX'),
+         ($2, 'Other Police Department', 'TX')`,
+      [AGENCY_A, AGENCY_B],
+    );
+  });
+
+  afterAll(async () => {
+    await admin?.end();
+  });
+
+  // -- Half one: an uncited value cannot exist ------------------------------
+
+  it("refuses a claim with no retrieval", async () => {
+    const message = await rejects(
+      `insert into public.claim
+         (claim_id, subject_type, subject_id, predicate, value_text,
+          source_record_key, confidence, confidence_basis)
+       values ('c_no_prov', 'agency', $1, 'agency.name', 'Uncited PD',
+               'src-1', 0.9, 'source_asserted')`,
+      [AGENCY_A],
+    );
+    expect(message).toMatch(/retrieval_id/);
+    expect(message).toMatch(/not-null|null value/i);
+  });
+
+  it("refuses a retrieval with neither a source URL nor a records-request id", async () => {
+    const message = await rejects(
+      `insert into public.source_retrieval
+         (retrieval_id, source_id, retrieved_at, content_hash)
+       values ('ret_no_locator', $1, now(), 'sha256:x')`,
+      [SOURCE],
+    );
+    expect(message).toMatch(/source_retrieval_locator_required/);
+  });
+
+  it("accepts a records-request identifier as the locator", async () => {
+    await admin.query(
+      `insert into public.source_retrieval
+         (retrieval_id, source_id, retrieved_at, records_request_id, content_hash)
+       values ('ret_foia', $1, now(), 'TCOLE-PIR-2026-0417', 'sha256:y')`,
+      [SOURCE],
+    );
+    const { rows } = await admin.query(
+      `select records_request_id from public.source_retrieval where retrieval_id = 'ret_foia'`,
+    );
+    expect(rows[0].records_request_id).toBe("TCOLE-PIR-2026-0417");
+  });
+
+  it("refuses confidence outside (0, 1]", async () => {
+    const message = await rejects(
+      `insert into public.claim
+         (claim_id, subject_type, subject_id, predicate, value_text,
+          retrieval_id, source_record_key, confidence, confidence_basis)
+       values ('c_bad_conf', 'agency', $1, 'agency.name', 'X', $2, 'k', 0, 'source_asserted')`,
+      [AGENCY_A, RETRIEVAL],
+    );
+    expect(message).toMatch(/confidence/);
+  });
+
+  it("refuses a value whose type does not match the declared predicate", async () => {
+    const message = await rejects(
+      `insert into public.claim
+         (claim_id, subject_type, subject_id, predicate, value_text,
+          retrieval_id, source_record_key, confidence, confidence_basis)
+       values ('c_wrong_type', 'agency', $1, 'agency.latitude', 'thirty-one',
+               $2, 'k', 0.9, 'source_asserted')`,
+      [AGENCY_A, RETRIEVAL],
+    );
+    expect(message).toMatch(/declared as number/);
+  });
+
+  it("refuses an unregistered predicate", async () => {
+    const message = await rejects(
+      `insert into public.claim
+         (claim_id, subject_type, subject_id, predicate, value_text,
+          retrieval_id, source_record_key, confidence, confidence_basis)
+       values ('c_unreg', 'agency', $1, 'agency.secret_field', 'x',
+               $2, 'k', 0.9, 'source_asserted')`,
+      [AGENCY_A, RETRIEVAL],
+    );
+    expect(message).toMatch(/claim_predicate|foreign key/i);
+  });
+
+  it("records a source-asserted null as a cited absence, not a missing row", async () => {
+    await admin.query(
+      `insert into public.claim
+         (claim_id, subject_type, subject_id, predicate, value_absent,
+          retrieval_id, source_record_key, confidence, confidence_basis,
+          publication_status)
+       values ('c_absent_lat', 'agency', $1, 'agency.latitude', true,
+               $2, 'tx-0001', 1.0, 'source_asserted', 'published')`,
+      [AGENCY_A, RETRIEVAL],
+    );
+    const { rows } = await admin.query(
+      `select cited_value from render.published_claim
+        where subject_id = $1 and predicate = 'agency.latitude'`,
+      [AGENCY_A],
+    );
+    expect(rows[0].cited_value.absent).toBe(true);
+    expect(rows[0].cited_value.value).toBeNull();
+    // The absence still carries a full citation.
+    expect(rows[0].cited_value.citation.source).toBe("fbi-cde-agency-registry");
+    expect(rows[0].cited_value.citation.retrievedAt).toBeTruthy();
+  });
+
+  it("keeps retrievals append-only so a citation date cannot be rewritten", async () => {
+    const message = await rejects(
+      `update public.source_retrieval set retrieved_at = now() - interval '1 year'
+        where retrieval_id = $1`,
+      [RETRIEVAL],
+    );
+    expect(message).toMatch(/append-only/);
+  });
+
+  // -- Half two: the render path cannot read an uncited value ---------------
+
+  describe("least-privilege render role", () => {
+    let renderer: Client;
+
+    beforeAll(async () => {
+      await admin.query(`alter role page_renderer login password 'test-only'`);
+
+      // `pg` ignores the `user`/`password` options when `connectionString` is
+      // also supplied, so the credentials must be embedded in the URL. Getting
+      // this wrong silently connects as the superuser and turns every
+      // permission assertion below into a false pass.
+      const url = new URL(DATABASE_URL!);
+      url.username = "page_renderer";
+      url.password = "test-only";
+      renderer = new Client({ connectionString: url.toString() });
+      await renderer.connect();
+
+      // Guard the guard. If this ever fails, the permission tests are
+      // meaningless and must not be allowed to report green.
+      const who = await renderer.query(`select current_user`);
+      expect(who.rows[0].current_user).toBe("page_renderer");
+    });
+
+    afterAll(async () => {
+      await renderer?.end();
+      await admin.query(`alter role page_renderer nologin`).catch(() => {});
+    });
+
+    it("cannot read the claim table directly", async () => {
+      await expect(
+        renderer.query(`select * from public.claim`),
+      ).rejects.toThrow(/permission denied/i);
+    });
+
+    it("cannot read the agency table directly", async () => {
+      await expect(
+        renderer.query(`select name from public.agency`),
+      ).rejects.toThrow(/permission denied/i);
+    });
+
+    it("cannot read the legacy officers table directly", async () => {
+      await expect(
+        renderer.query(`select first_name from public.officers`),
+      ).rejects.toThrow(/permission denied/i);
+    });
+
+    it("cannot select a bare value column from the render view", async () => {
+      // The columns do not exist. This is the point: there is no SQL that
+      // returns a value without its citation.
+      await expect(
+        renderer.query(`select value_text from render.published_claim`),
+      ).rejects.toThrow(/column .*value_text.* does not exist/i);
+    });
+
+    it("returns value and citation as one indivisible column", async () => {
+      await admin.query(
+        `insert into public.claim
+           (claim_id, subject_type, subject_id, predicate, value_text,
+            retrieval_id, source_record_key, confidence, confidence_basis,
+            publication_status)
+         values ('c_pub_name', 'agency', $1, 'agency.name', 'Test Police Department',
+                 $2, 'tx-0001', 0.99, 'source_asserted', 'published')`,
+        [AGENCY_A, RETRIEVAL],
+      );
+
+      const { rows } = await renderer.query(
+        `select cited_value from render.published_claim
+          where subject_id = $1 and predicate = 'agency.name'`,
+        [AGENCY_A],
+      );
+
+      expect(rows).toHaveLength(1);
+      const cited = rows[0].cited_value;
+      expect(cited.value).toBe("Test Police Department");
+      expect(cited.citation).toMatchObject({
+        source: "fbi-cde-agency-registry",
+        publisher: "Federal Bureau of Investigation",
+        locatorType: "url",
+        locator: "https://api.usa.gov/crime/fbi/cde/agency",
+        confidence: 0.99,
+        confidenceBasis: "source_asserted",
+      });
+      expect(cited.citation.retrievedAt).toBeTruthy();
+    });
+
+    it("hides staged claims from the render path", async () => {
+      await admin.query(
+        `insert into public.claim
+           (claim_id, subject_type, subject_id, predicate, value_text,
+            retrieval_id, source_record_key, confidence, confidence_basis)
+         values ('c_staged', 'agency', $1, 'agency.name', 'Staged Name',
+                 $2, 'tx-0002', 0.5, 'source_asserted')`,
+        [AGENCY_B, RETRIEVAL],
+      );
+      const { rows } = await renderer.query(
+        `select cited_value from render.published_claim where subject_id = $1`,
+        [AGENCY_B],
+      );
+      expect(rows).toHaveLength(0);
+    });
+
+    it("is not granted access to the personnel view at all", async () => {
+      await expect(
+        renderer.query(`select * from render.published_person`),
+      ).rejects.toThrow(/permission denied/i);
+    });
+
+    it("removes a subject from render the moment it is suppressed", async () => {
+      const before = await renderer.query(
+        `select count(*)::int as n from render.published_claim where subject_id = $1`,
+        [AGENCY_A],
+      );
+      expect(before.rows[0].n).toBeGreaterThan(0);
+
+      await admin.query(
+        `insert into public.subject_suppression
+           (suppression_id, subject_type, subject_id, reason_code, applied_by)
+         values ('sup_1', 'agency', $1, 'accuracy_dispute', 'founding-engineer')`,
+        [AGENCY_A],
+      );
+
+      const during = await renderer.query(
+        `select count(*)::int as n from render.published_claim where subject_id = $1`,
+        [AGENCY_A],
+      );
+      expect(during.rows[0].n).toBe(0);
+
+      await admin.query(
+        `update public.subject_suppression
+            set lifted_at = now(), lifted_by = 'founding-engineer'
+          where suppression_id = 'sup_1'`,
+      );
+
+      const after = await renderer.query(
+        `select count(*)::int as n from render.published_claim where subject_id = $1`,
+        [AGENCY_A],
+      );
+      expect(after.rows[0].n).toBeGreaterThan(0);
+    });
+  });
+
+  // -- Publication policy ---------------------------------------------------
+
+  it("refuses to publish a claim on a non-renderable predicate", async () => {
+    const message = await rejects(
+      `insert into public.claim
+         (claim_id, subject_type, subject_id, predicate, value_text,
+          retrieval_id, source_record_key, confidence, confidence_basis,
+          publication_status)
+       values ('c_type_name', 'agency', $1, 'agency.agency_type_name', 'State Police',
+               $2, 'tx-0001', 0.9, 'source_asserted', 'published')`,
+      [AGENCY_A, RETRIEVAL],
+    );
+    expect(message).toMatch(/not renderable/);
+  });
+
+  it("refuses to publish a claim backed by a source whose terms are not cleared", async () => {
+    await admin.query(
+      `insert into public.source
+         (source_id, slug, name, publisher, access_basis, terms_status)
+       values ('src_uncleared', 'npi', 'National Police Index', 'NPI',
+               'public_bulk_download', 'under_review')`,
+    );
+    await admin.query(
+      `insert into public.source_retrieval
+         (retrieval_id, source_id, retrieved_at, source_url, content_hash)
+       values ('ret_uncleared', 'src_uncleared', now(), 'https://example.org/x', 'sha256:z')`,
+    );
+    const message = await rejects(
+      `insert into public.claim
+         (claim_id, subject_type, subject_id, predicate, value_text,
+          retrieval_id, source_record_key, confidence, confidence_basis,
+          publication_status)
+       values ('c_uncleared', 'agency', $1, 'agency.name', 'X',
+               'ret_uncleared', 'k', 0.9, 'source_asserted', 'published')`,
+      [AGENCY_B],
+    );
+    expect(message).toMatch(/terms_status=under_review/);
+  });
+
+  it("writes an audit event for every publication-status transition", async () => {
+    await admin.query(`set intake.actor = 'founding-engineer'`);
+    await admin.query(`set intake.reason_code = 'gate_cleared'`);
+    await admin.query(
+      `update public.claim set publication_status = 'published' where claim_id = 'c_staged'`,
+    );
+    await admin.query(
+      `update public.claim set publication_status = 'blocked' where claim_id = 'c_staged'`,
+    );
+
+    const { rows } = await admin.query(
+      `select from_status, to_status, actor, reason_code
+         from public.publication_event
+        where claim_id = 'c_staged'
+        order by occurred_at`,
+    );
+
+    // insert(staged) -> published -> blocked
+    expect(rows.map((r) => r.to_status)).toEqual([
+      "staged",
+      "published",
+      "blocked",
+    ]);
+    expect(rows[1].from_status).toBe("staged");
+    expect(rows[2].from_status).toBe("published");
+    expect(rows[2].actor).toBe("founding-engineer");
+    expect(rows[2].reason_code).toBe("gate_cleared");
+    await admin.query(`reset intake.actor`);
+    await admin.query(`reset intake.reason_code`);
+  });
+
+  it("keeps the publication audit trail append-only", async () => {
+    const message = await rejects(
+      `delete from public.publication_event where claim_id = 'c_staged'`,
+    );
+    expect(message).toMatch(/append-only/);
+  });
+
+  // -- Agency identity ------------------------------------------------------
+
+  describe("ORI identity", () => {
+    it("records the ORI form explicitly and rejects a length mismatch", async () => {
+      const message = await rejects(
+        `insert into public.agency_ori
+           (agency_ori_id, agency_id, ori, ori_form, retrieval_id, confidence)
+         values ('aori_bad', $1, 'TX0570000', 'ori7', $2, 1.0)`,
+        [AGENCY_A, RETRIEVAL],
+      );
+      expect(message).toMatch(/agency_ori_form_length/);
+    });
+
+    it("derives ori7 from a 9-character ORI without overwriting it", async () => {
+      await admin.query(
+        `insert into public.agency_ori
+           (agency_ori_id, agency_id, ori, ori_form, is_primary, retrieval_id, confidence)
+         values ('aori_a', $1, 'TX0570000', 'ori9', true, $2, 1.0)`,
+        [AGENCY_A, RETRIEVAL],
+      );
+      const { rows } = await admin.query(
+        `select ori, ori_form, ori7 from public.agency_ori where agency_ori_id = 'aori_a'`,
+      );
+      expect(rows[0]).toMatchObject({
+        ori: "TX0570000",
+        ori_form: "ori9",
+        ori7: "TX05700",
+      });
+    });
+
+    it("opens a reviewed conflict instead of auto-resolving an ORI collision", async () => {
+      await admin.query(
+        `insert into public.agency_ori
+           (agency_ori_id, agency_id, ori, ori_form, is_primary, retrieval_id, confidence)
+         values ('aori_b', $1, 'TX0570001', 'ori9', true, $2, 1.0)`,
+        [AGENCY_B, RETRIEVAL],
+      );
+
+      const { rows } = await admin.query(
+        `select conflict_type, status, evidence from public.ori_conflict where ori7 = 'TX05700'`,
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        conflict_type: "same_ori_multiple_agencies",
+        status: "open",
+      });
+      expect(rows[0].evidence.agency_ids).toEqual(
+        expect.arrayContaining([AGENCY_A, AGENCY_B]),
+      );
+    });
+
+    it("suppresses both agencies from render while the ORI conflict is open", async () => {
+      const { rows } = await admin.query(
+        `select count(*)::int as n from render.published_agency
+          where agency_id in ($1, $2)`,
+        [AGENCY_A, AGENCY_B],
+      );
+      expect(rows[0].n).toBe(0);
+    });
+
+    it("refuses to close a conflict without a resolver and a note", async () => {
+      const message = await rejects(
+        `update public.ori_conflict set status = 'resolved' where ori7 = 'TX05700'`,
+      );
+      expect(message).toMatch(/ori_conflict_resolution_complete/);
+    });
+
+    it("refuses an ORI assignment with no citation", async () => {
+      const message = await rejects(
+        `insert into public.agency_ori
+           (agency_ori_id, agency_id, ori, ori_form, confidence)
+         values ('aori_nocite', $1, 'TX0990000', 'ori9', 1.0)`,
+        [AGENCY_A],
+      );
+      expect(message).toMatch(/retrieval_id/);
+    });
+
+    it("allows an agency to belong to at most one department entity", async () => {
+      await admin.query(
+        `insert into public.agency_entity
+           (agency_entity_id, state, canonical_name, entity_kind)
+         values ('ent_chp', 'CA', 'California Highway Patrol', 'state_police'),
+                ('ent_other', 'CA', 'Other Department', 'municipal_police')`,
+      );
+      await admin.query(
+        `insert into public.agency_entity_member
+           (membership_id, agency_entity_id, agency_id, confidence, method, evidence)
+         values ('mem_1', 'ent_chp', $1, 0.9, 'shared_ori_prefix',
+                 '{"ori7_prefix": "CA05700"}')`,
+        [AGENCY_A],
+      );
+      const message = await rejects(
+        `insert into public.agency_entity_member
+           (membership_id, agency_entity_id, agency_id, confidence, method, evidence)
+         values ('mem_2', 'ent_other', $1, 0.9, 'name_pattern', '{}')`,
+        [AGENCY_A],
+      );
+      expect(message).toMatch(/agency_entity_member_unique/);
+    });
+
+    it("models absence from a registry as a finding, not a missing row", async () => {
+      await admin.query(
+        `insert into public.agency_registry_presence
+           (presence_id, agency_id, source_id, presence, retrieval_id, note)
+         values ('pres_1', $1, $2, 'absent', $3,
+                 'Not a UCR reporting participant; existence confirmed by state roster')`,
+        [AGENCY_B, SOURCE, RETRIEVAL],
+      );
+      const { rows } = await admin.query(
+        `select presence from public.agency_registry_presence where presence_id = 'pres_1'`,
+      );
+      expect(rows[0].presence).toBe("absent");
+    });
+  });
+
+  // -- Personnel identity resolution ---------------------------------------
+
+  describe("personnel identity", () => {
+    beforeAll(async () => {
+      await admin.query(
+        `insert into public.person (person_id) values ('per_a'), ('per_b')`,
+      );
+      await admin.query(
+        `insert into public.person_name_variant
+           (name_variant_id, person_id, full_name, first_name, last_name,
+            normalized_key, retrieval_id, source_record_key, confidence)
+         values
+           ('pnv_1', 'per_a', 'Jose Gonzalez', 'Jose', 'Gonzalez',
+            'gonzalez|jose', $1, 'tcole-1', 1.0),
+           ('pnv_2', 'per_b', 'Jose A. Gonzalez', 'Jose', 'Gonzalez',
+            'gonzalez|jose', $1, 'tcole-2', 1.0)`,
+        [RETRIEVAL],
+      );
+    });
+
+    it("has no displayable attribute columns on person", async () => {
+      const { rows } = await admin.query(
+        `select column_name from information_schema.columns
+          where table_schema = 'public' and table_name = 'person'`,
+      );
+      const columns = rows.map((r) => r.column_name).sort();
+      // Nothing name-like. A person's name can only exist as a cited variant.
+      expect(columns).toEqual([
+        "created_at",
+        "legacy_officer_id",
+        "person_id",
+        "updated_at",
+      ]);
+    });
+
+    it("requires a citation on every name variant", async () => {
+      const message = await rejects(
+        `insert into public.person_name_variant
+           (name_variant_id, person_id, full_name, normalized_key,
+            source_record_key, confidence)
+         values ('pnv_bad', 'per_a', 'Uncited Name', 'k', 'k', 1.0)`,
+      );
+      expect(message).toMatch(/retrieval_id/);
+    });
+
+    it("links identities without merging rows", async () => {
+      await admin.query(
+        `insert into public.person_identity_link
+           (link_id, person_id_a, person_id_b, assertion, confidence, method,
+            evidence, status)
+         values ('lnk_1', 'per_a', 'per_b', 'possible_same_person', 0.72,
+                 'name_and_agency_overlap',
+                 '{"shared_agency": "TX0570000", "name_similarity": 0.94}', 'proposed')`,
+      );
+      // Both person rows still exist, untouched. A link is reversible; a merge
+      // would not be.
+      const { rows } = await admin.query(
+        `select count(*)::int as n from public.person where person_id in ('per_a','per_b')`,
+      );
+      expect(rows[0].n).toBe(2);
+    });
+
+    it("refuses an unordered or self-referential identity pair", async () => {
+      const selfLink = await rejects(
+        `insert into public.person_identity_link
+           (link_id, person_id_a, person_id_b, assertion, confidence, method, evidence)
+         values ('lnk_self', 'per_a', 'per_a', 'same_person', 1.0, 'manual_review', '{}')`,
+      );
+      expect(selfLink).toMatch(/person_identity_link_ordered/);
+
+      const reversed = await rejects(
+        `insert into public.person_identity_link
+           (link_id, person_id_a, person_id_b, assertion, confidence, method, evidence)
+         values ('lnk_rev', 'per_b', 'per_a', 'same_person', 1.0, 'manual_review', '{}')`,
+      );
+      expect(reversed).toMatch(/person_identity_link_ordered/);
+    });
+
+    it("refuses to auto-accept a same-person link from a probabilistic method", async () => {
+      const message = await rejects(
+        `insert into public.person_identity_link
+           (link_id, person_id_a, person_id_b, assertion, confidence, method,
+            evidence, status, reviewed_by, reviewed_at)
+         values ('lnk_auto', 'per_a', 'per_b', 'same_person', 0.99,
+                 'probabilistic_score', '{}', 'accepted', 'matcher', now())`,
+      );
+      expect(message).toMatch(/person_identity_link_same_person_needs_review/);
+    });
+
+    it("requires a reviewer on any non-proposed link", async () => {
+      const message = await rejects(
+        `insert into public.person_identity_link
+           (link_id, person_id_a, person_id_b, assertion, confidence, method,
+            evidence, status)
+         values ('lnk_norev', 'per_a', 'per_b', 'distinct_person', 1.0,
+                 'manual_review', '{}', 'accepted')`,
+      );
+      expect(message).toMatch(/person_identity_link_review_complete/);
+    });
+
+    it("keeps rank, badge number and dates as claims rather than columns", async () => {
+      const { rows } = await admin.query(
+        `select column_name from information_schema.columns
+          where table_schema = 'public' and table_name = 'employment_period'`,
+      );
+      const columns = rows.map((r) => r.column_name);
+      for (const forbidden of [
+        "rank",
+        "badge_number",
+        "start_date",
+        "end_date",
+        "license_type",
+      ]) {
+        expect(columns).not.toContain(forbidden);
+      }
+    });
+
+    it("refuses an employment period with no citation", async () => {
+      const message = await rejects(
+        `insert into public.employment_period
+           (employment_id, person_id, agency_id, source_record_key, confidence)
+         values ('emp_nocite', 'per_a', $1, 'k', 1.0)`,
+        [AGENCY_A],
+      );
+      expect(message).toMatch(/retrieval_id/);
+    });
+
+    it("defaults employment to staged, never published", async () => {
+      await admin.query(
+        `insert into public.employment_period
+           (employment_id, person_id, agency_id, retrieval_id, source_record_key, confidence)
+         values ('emp_1', 'per_a', $1, $2, 'tcole-1', 1.0)`,
+        [AGENCY_A, RETRIEVAL],
+      );
+      const { rows } = await admin.query(
+        `select publication_status from public.employment_period where employment_id = 'emp_1'`,
+      );
+      expect(rows[0].publication_status).toBe("staged");
+    });
+
+    it("keeps the personnel gate closed even for a published employment", async () => {
+      await admin.query(
+        `update public.employment_period set publication_status = 'published'
+          where employment_id = 'emp_1'`,
+      );
+      const { rows } = await admin.query(
+        `select count(*)::int as n from render.published_person`,
+      );
+      // Second lock: the view itself yields nothing. Opening the gate takes a
+      // migration AND a grant.
+      expect(rows[0].n).toBe(0);
+    });
+  });
+
+  // -- The invariant self-check --------------------------------------------
+
+  describe("assert_provenance_invariant", () => {
+    it("reports no violations on a correctly migrated database", async () => {
+      const { rows } = await admin.query(
+        `select violation, detail from public.assert_provenance_invariant()`,
+      );
+      expect(rows).toEqual([]);
+    });
+
+    it("detects a future migration granting the renderer a base table", async () => {
+      await admin.query(`grant select on public.claim to page_renderer`);
+      const { rows } = await admin.query(
+        `select violation, detail from public.assert_provenance_invariant()`,
+      );
+      expect(rows.map((r) => r.violation)).toContain(
+        "renderer_reads_base_table",
+      );
+      expect(rows.some((r) => r.detail.includes("public.claim"))).toBe(true);
+      await admin.query(`revoke select on public.claim from page_renderer`);
+    });
+
+    it("detects the personnel gate being opened by a grant", async () => {
+      await admin.query(
+        `grant select on render.published_person to page_renderer`,
+      );
+      const { rows } = await admin.query(
+        `select violation from public.assert_provenance_invariant()`,
+      );
+      expect(rows.map((r) => r.violation)).toContain("personnel_gate_open");
+      await admin.query(
+        `revoke select on render.published_person from page_renderer`,
+      );
+    });
+
+    it("is clean again once the offending grants are revoked", async () => {
+      const { rows } = await admin.query(
+        `select violation, detail from public.assert_provenance_invariant()`,
+      );
+      expect(rows).toEqual([]);
+    });
+  });
+});

--- a/test/schema/upstream-fixture.sql
+++ b/test/schema/upstream-fixture.sql
@@ -1,0 +1,50 @@
+-- Minimal stand-in for the pre-existing objects that
+-- 20260824170000_provenance_structural_invariant.sql references.
+--
+-- Applied ONLY when public.agency does not already exist, so that against a
+-- real `supabase db reset` database this file is skipped entirely and the
+-- migration is exercised against the actual 45-table schema.
+--
+-- Column definitions are copied from
+-- supabase/migrations/20250303232529_initial_schema.sql. PostGIS-dependent
+-- columns (location_path_id, geometry) are omitted -- the provenance migration
+-- does not reference them, and PostGIS is not available on a bare Postgres.
+
+create extension if not exists pgcrypto;
+
+create or replace function public.generate_cuid()
+returns text
+language plpgsql
+as $$
+begin
+    return lower(
+        'c'
+        || to_char(extract(epoch from current_timestamp), 'FM9999999999')
+        || substring(md5(random()::text) for 8)
+    );
+end;
+$$;
+
+create table if not exists public.agency (
+    id text primary key default public.generate_cuid(),
+    name text not null,
+    city text,
+    state text not null,
+    address text,
+    zip_code text,
+    contact_name text,
+    contact_email text,
+    created_at timestamp with time zone not null default timezone('utc'::text, now()),
+    updated_at timestamp with time zone not null default timezone('utc'::text, now())
+);
+
+create table if not exists public.officers (
+    id text primary key default public.generate_cuid(),
+    first_name text not null,
+    last_name text not null,
+    middle_name text,
+    prefix text,
+    suffix text,
+    created_at timestamp with time zone not null default timezone('utc'::text, now()),
+    updated_at timestamp with time zone not null default timezone('utc'::text, now())
+);


### PR DESCRIPTION
Closes the schema half of **INS-5**. Purely additive: no existing table is altered or dropped, no data reset, no generated type refresh.

## The problem

The schema cannot cite itself. Across all 146 KB of migrations, `provenance`, `citation`, `retrieved_at` and `attribution` each appear **zero** times. `source_url` exists only on `civil_cases`; `confidence` only on `coverage_links`. The two tables behind 99.7% of the public page surface — `officers` and `agency_officers` — carry no source, no retrieval date, and no confidence. A blanket footer disclaimer stands in for per-field citation.

## Why this is not a column addition

"A field without provenance does not render" is two requirements, and each needs its own mechanism.

**1. An uncited value cannot exist.** Displayable values become `public.claim` rows with `retrieval_id NOT NULL`. A retrieval cannot exist without a source, a retrieval timestamp, and either a source URL or a records-request identifier — a CHECK constraint, not a code review. `source_retrieval` is append-only by trigger, because a mutable citation date is a falsifiable citation.

**2. An uncited value cannot be read by the render path.** `render.published_claim` has exactly four columns and **no bare value column**:

```
subject_type | subject_id | predicate | cited_value
```

`cited_value` is a jsonb holding the value and its citation in the same field, so no projection can separate them. The page build connects as `page_renderer`, whose entire privilege set is:

```
render.published_agency [SELECT]
render.published_claim  [SELECT]
```

As that role, `select count(*) from public.claim` returns `ERROR: permission denied for schema public`.

Either mechanism alone is insufficient. Row-level provenance is a convention — select the value, drop the citation column. Role isolation alone is bypassable — point the renderer at a base table. Together, an uncited render is unreachable rather than discouraged.

**3. The invariant does not decay.** `public.assert_provenance_invariant()` (`npm run assert:provenance`) fails the build if a later migration grants the renderer a base table, grants outside the reviewed render allowlist, opens the personnel gate, or exposes a bare value column.

## Also modeled now

Both are join-key problems that become backfills against a live corpus if deferred.

**ORI identity.** `ori_form` is explicit and length-checked, because federal datasets mix 7- and 9-character ORIs and an unlabeled `ori` column silently fails to join — which in this domain means a page about the wrong department. `agency_entity` sits above the ORI reporting unit: the FBI registry returns **148 agencies typed `State Police` for California** and 1 for Texas, so without that layer CHP renders as 148 separate departments. ORI collisions open a reviewed `ori_conflict` and withhold the affected agencies from render rather than auto-resolving. `agency_registry_presence` makes "absent from the registry" a finding distinct from "does not exist" — the federal source is a UCR-*participation* registry, and Puerto Rico returns 1 agency.

**Personnel entity resolution.** `person` is deliberately attribute-free — there is no `person.first_name` that could ever render uncited, and a test asserts the column list. Names are cited variants. `person_identity_link` records confidence-scored, reversible assertions and never merges rows: a wrong merge attributes one officer's misconduct to a different human being and cannot be undone. Automated probabilistic methods cannot self-accept a `same_person` link.

**Publication and suppression.** `staged` / `published` / `blocked` / `quarantined`, subject-level suppression, and a trigger-written append-only audit trail, so correction and takedown work from day one. `blocked` and `quarantined` are distinct on purpose — one is a policy decision, the other a data-quality decision, and they escalate to different people.

## Personnel gate

`render.published_person` is defined to return **zero rows** *and* is not granted to `page_renderer`. Two independent locks; removing one does not open the gate. Opening it requires a migration plus a grant, both reviewable, and Data Integrity & Publication Risk Reviewer clearance per INS-11.

## Verification

42 tests, each attempting the thing the invariant forbids and asserting refusal.

```
createdb intake_schema_test
TEST_DATABASE_URL=postgres://localhost:5432/intake_schema_test npx vitest run test/schema
# 42 passed
```

Full suite: 229 passed with a database, 187 passed / 42 skipped without one. `test/seed-display.test.ts` fails on this branch and on `main` alike — `supabase/seed.sql` is produced by `link-seed.sh` and is not checked in.

**One note worth flagging.** The first draft passed all four permission tests while silently connected as the superuser: `pg` ignores the `user` option when `connectionString` is also set. That is a false green on the single most important assertion in the change. The suite now asserts `current_user = 'page_renderer'` before those tests so it cannot recur.

## Required before merge

- [ ] Run `test/schema` against a real `supabase db reset` database. PostGIS is unavailable on the verification host, so `test/schema/upstream-fixture.sql` stands in for the referenced upstream objects; it is skipped automatically when `public.agency` already exists.
- [ ] `npm run lint:sql` (sqlfluff) — needs `mise`/`uvx`.
- [ ] `npm run openspec:validate` — needs the `openspec` binary.

## Deliberately out of scope

- **Backfilling the 132,109 live personnel pages onto the claim model.** They have no retrieval records to point at, and manufacturing a citation for a value whose origin we cannot demonstrate would be worse than having none. Blocked on INS-11.
- Retiring the legacy value columns on `agency` / `officers` / `agency_officers`. They stay; the renderer simply cannot read them.
- Applying this migration to production — a separate decision with a deploy owner.

OpenSpec change artifacts are in `openspec/changes/2026-08-24-provenance-structural-invariant/`.

Refs INS-5.