### PR TITLE
Corrections and takedown mechanics with an audit trail

### DIFF
--- a/openspec/changes/2026-08-24-corrections-and-takedown/design.md
+++ b/openspec/changes/2026-08-24-corrections-and-takedown/design.md
@@ -1,0 +1,143 @@
+# Design
+
+## The failure this is built around
+
+> A takedown honoured on Tuesday and undone by a re-import on Wednesday.
+
+There are two distinct versions of that failure and they need different
+defences.
+
+**Version A — the pipeline overwrites the record.** The loader classifies an
+existing agency with owned columns as an `update` and writes `public.agency`
+directly. Under a legal hold that overwrites the record we are holding. The
+suppression row survives, so the page stays down, but the contents of the held
+record are gone.
+
+**Version B — the pipeline reintroduces the record under a new ID.** Intake
+maps source record keys to canonical cuid2 IDs through a YAML ledger on disk.
+`subject_suppression` is keyed on the canonical ID. If that ledger is
+regenerated, the same upstream row is assigned a fresh canonical ID, and every
+suppression check keyed on the old ID passes. The record comes back.
+
+Version B is the dangerous one, because it is silent, because the ledger lives
+outside the database where the suppression lives, and because nothing about it
+looks like a failure. The import succeeds. The row count goes up by one.
+
+## Why suppression is anchored to the source record key
+
+The only identifier that does not change when our ID mapping changes is the
+source's own. `public.claim` already carries `source_record_key`, so at the
+moment a subject is suppressed we can enumerate the exact upstream rows behind
+it and record them in `suppression_source_key`.
+
+Capture is by trigger, not by convention. Whoever honours a takedown at 11pm is
+not going to remember to also enumerate the upstream record keys, and a
+suppression that missed them looks identical to one that did not — until the
+next import.
+
+The guard on `public.claim` therefore checks two things, and either one blocks
+the write:
+
+1. is the subject's canonical ID suppressed?
+2. is the `(source_id, source_record_key)` behind this claim suppressed?
+
+Check 2 is what catches Version B.
+
+## Why the ID lookup ignores subject_type
+
+`is_id_suppressed(subject_id)` deliberately does not filter on `subject_type`.
+Canonical IDs are cuid2 and globally unique, so a match is a match. A
+suppression filed against `subject_type='person'` must still stop a write that
+calls the same ID an `'officer'`. A type mismatch between the suppression and
+the write is exactly the near-miss that would otherwise let a record through,
+and being over-broad here costs nothing.
+
+## Why the guard raises instead of skipping
+
+A trigger that silently dropped suppressed rows would turn a serious event into
+a log line nobody reads. It raises. A loader trying to reintroduce suppressed
+material should stop and be looked at.
+
+To keep that a backstop rather than the routine path, `classifyDatabaseOperations`
+reads active suppressions and demotes a suppressed row's operation from
+`update` to `read`. A honoured takedown then costs one skipped record instead
+of a broken pipeline. Intake reads suppression state through the same
+`intake_writer` role that cannot write it.
+
+## Why two independent defences
+
+The triggers stop an accidental un-suppression. They do not stop a deliberate
+one, and they do not survive a future migration that drops a trigger — which is
+exactly the kind of thing that happens during an unrelated refactor eighteen
+months from now.
+
+So `intake_writer` holds SELECT and nothing else on the suppression tables.
+Removing that protection requires writing a GRANT, which
+`assert_suppression_invariant()` fails the build on. Neither defence depends on
+the other.
+
+`intake_writer` needs SELECT, not zero access: the planner has to see what is
+suppressed in order to skip it.
+
+## Why lifting returns claims to `staged`, not to `published`
+
+A suppression gets lifted for several different reasons — the accuracy dispute
+was resolved, the wrong subject was suppressed, a legal hold expired, someone
+made a mistake filing it. None of those is the same decision as "this record is
+fit to publish."
+
+Restoring the prior publication status would make an accidental lift
+immediately re-expose a public page. Returning to `staged` means republication
+is a separate act with its own audit event. The cost is that a legitimately
+lifted record needs a second, deliberate step. That is the correct direction to
+be wrong in.
+
+## The naming rule in the public corrections log
+
+This is the hard call in the change.
+
+A corrections log that says _"removed the record for [name] on 2026-08-24
+following a removal request"_ republishes exactly the association the removal
+was meant to end — and does it on a page built to be crawled and indexed. The
+log would become a directory of people who asked to be taken down.
+
+So the rule is asymmetric:
+
+- **Agencies are named.** An agency is not a data subject, and the public
+  interest in knowing that we corrected a department's record is real and
+  direct.
+- **Anything concerning a person is date, action, and coarse reason only.** No
+  subject ID, no identifying detail.
+- **Requester identity never appears at any granularity**, for either.
+
+`assert_suppression_invariant()` checks the view's own output for a disclosed
+non-agency subject ID, so this holds as an assertion about data rather than an
+intention about SQL.
+
+The cost is that the log is less informative for the personnel corpus, which is
+the larger half. That is the right trade: a corrections log exists to show we
+correct things, not to re-identify the people we corrected.
+
+## What this change does not decide
+
+Per the INS-9 boundary: it builds the mechanism and decides nothing about what
+gets taken down. The schema enforces that boundary rather than documenting it —
+a `legal_demand` cannot be resolved without escalation, and a suspected sealed
+or expunged record cannot be declined at all.
+
+## Known gaps, deliberately left
+
+**The legacy entity tables have no source-key linkage.** `public.agency` and
+`public.officers` predate the claim model and carry no `source_record_key`
+column, so Version B cannot be blocked in the database for them — there is
+nothing to compare against. The guard on those tables covers UPDATE and DELETE
+of a suppressed row (Version A) but cannot recognise a re-created row under a
+new ID. Those tables are what render the 132,109 live personnel pages, so this
+gap is real and not theoretical. Closing it means plumbing source record keys
+through `ImportRows`, which belongs with the loader audit.
+
+**Suppressed skips are not yet in the change diff.** The planner demotes a
+suppressed row to `read`, which is correct behaviour, but the count does not
+surface in the load's change diff.
+
+Both are tracked as follow-up issues.

--- a/openspec/changes/2026-08-24-corrections-and-takedown/proposal.md
+++ b/openspec/changes/2026-08-24-corrections-and-takedown/proposal.md
@@ -1,0 +1,115 @@
+## Why
+
+We publish claims about named human beings, and 132,109 officer pages are
+already live (INS-11). The first correction request or takedown demand will
+arrive with no intake path, no suppression procedure, and no audit trail. The
+first time we need this we will need it urgently, which is the worst time to
+design it.
+
+`20260824170000_provenance_structural_invariant.sql` established suppression
+STATE: an active `subject_suppression` row removes a subject from every render
+view, and `publication_event` is an append-only status log. Four things are
+missing, and each of them is a way a takedown fails silently.
+
+**1. There is no intake path.** Correction requests and takedown demands arrive
+by email, web form, and attorney letter and currently land in a person's inbox.
+Nothing records what was asked, when it arrived, or what we did about it.
+
+**2. The ingestion pipeline can undo a takedown.** The loader connects with
+full rights on `public`. Nothing prevents a re-import from setting `lifted_at`
+or deleting the suppression row. A takedown honoured on Tuesday and undone by
+Wednesday's re-import is currently reachable, and it would leave no trace that
+it had ever been honoured.
+
+**3. Re-identification launders a takedown, and this is the subtle one.**
+Intake maps source record keys to canonical cuid2 IDs through an on-disk YAML
+ledger (`src/cli/state/source-name-to-canonical-id`). `subject_suppression` is
+keyed on the canonical ID. If that ledger is regenerated, lost, or diverges
+from the database, a re-import assigns a NEW canonical ID to the SAME upstream
+record. The suppression row survives untouched, still pointing at the old ID,
+and protects nothing. Every canonical-ID check passes. The record comes back.
+
+Suppression keyed only on our own identifier cannot survive a change to our own
+identifier. It has to be anchored to something the source controls.
+
+**4. There is no public corrections log.** An accountability organisation that
+corrects records privately is asking for a trust it does not extend to anyone
+else.
+
+## What Changes
+
+**Intake**
+
+- From: Requests arrive in an inbox and are handled ad hoc.
+- To: `public.correction_request` records channel, kind, the requester's
+  verbatim text, and disposition. Request substance is immutable after intake
+  and the row cannot be deleted.
+- Reason: If our handling of a demand is ever questioned, a paraphrase is
+  worthless.
+- Impact: New table. No existing table is altered.
+
+**The INS-9 boundary, enforced**
+
+- From: "Route legal demands to the Executive Director" is a paragraph in
+  AGENTS.md.
+- To: A trigger refuses to mark a `legal_demand` or `sealed_or_expunged`
+  request `action_taken` or `declined` unless it was escalated first, and
+  refuses to decline a suspected sealed record at all. A resolved request must
+  name who decided.
+- Reason: Deciding what a legal demand requires is a legal determination.
+  Engineering does not make those, and the schema should not let it.
+
+**Suppression that survives a re-import**
+
+- From: Suppression is keyed on the canonical ID only.
+- To: `public.suppression_source_key` records the upstream `(source_id,
+source_record_key)` pairs behind a subject, captured by trigger at the moment
+  of suppression. `claim` writes are refused if the subject OR the upstream
+  record key is suppressed. `public.agency` and `public.officers` refuse
+  UPDATE and DELETE on a suppressed row.
+- Reason: A re-import must fail closed whether or not our ID mapping survived.
+
+**Suppression is applied and lifted under audit, never deleted**
+
+- From: `subject_suppression` rows are freely updatable and deletable.
+- To: DELETE is refused outright. UPDATE is restricted to the lift fields, once,
+  and requires a `lift_note`. Apply and lift both write `publication_event`.
+- Reason: Deleting a suppression destroys the evidence that we honoured a
+  takedown, which is the record we would most need.
+
+**Lifting does not republish**
+
+- From: Undefined.
+- To: Lifting a suppression returns the subject's claims to `staged`, never to
+  `published`.
+- Reason: A suppression is lifted for many reasons and none of them are the
+  same decision as "this is fit to publish". An accidental lift must not
+  re-expose a page.
+
+**Least-privilege ingestion role**
+
+- From: The loader connects with full rights on `public`.
+- To: `intake_writer` holds DML on the data tables and SELECT-only on the
+  suppression tables and the audit log.
+- Reason: The triggers stop an accidental un-suppression. This stops a
+  deliberate one, and it survives a future migration that drops a trigger.
+
+**Public corrections log**
+
+- From: None.
+- To: `render.corrections_log`, granted to `page_renderer`.
+- Reason: Distribution and accountability. See design.md for the naming rule --
+  agencies are named, people are not.
+
+## Impact
+
+- Purely additive. No existing table is altered or dropped.
+- Depends on `20260824170000_provenance_structural_invariant.sql` (PR #60);
+  this migration must be applied after it.
+- Loaders must be repointed to connect as `intake_writer`. A loader still
+  connecting as the database owner is outside the privilege guarantee, which is
+  why `assert_suppression_invariant()` checks grants rather than trusting the
+  connection string.
+- `assert_provenance_invariant()` is redefined to widen its render-view
+  allowlist by one entry. All four of its checks are otherwise unchanged.
+- Requires a generated type refresh in downstream consumers. No data reset.

--- a/openspec/changes/2026-08-24-corrections-and-takedown/specs/corrections-and-takedown/spec.md
+++ b/openspec/changes/2026-08-24-corrections-and-takedown/specs/corrections-and-takedown/spec.md
@@ -1,0 +1,185 @@
+## ADDED Requirements
+
+### Requirement: Correction Requests And Takedown Demands Are Recorded Verbatim
+
+An arriving correction request or takedown demand MUST be recorded with its
+channel, kind, and the requester's own words. The substance of a request MUST
+NOT be editable after intake, and a request MUST NOT be deletable.
+
+#### Scenario: A request is recorded with the requester's own words
+
+- **WHEN** a correction request is inserted
+- **THEN** the row is stored with disposition `received` and the request text unchanged
+
+#### Scenario: Request substance cannot be rewritten
+
+- **WHEN** an update attempts to change `request_text`, requester identity, channel, kind, or `received_at`
+- **THEN** the database rejects it as immutable after intake
+
+#### Scenario: A request cannot be deleted
+
+- **WHEN** a delete is attempted against `correction_request`
+- **THEN** the database rejects it
+
+#### Scenario: A resolved request must name who decided
+
+- **WHEN** a request is set to `action_taken` or `declined` without `decided_at` and `decided_by`
+- **THEN** the database rejects the write with `correction_request_resolution_attributed`
+
+### Requirement: Legal Determinations Are Routed, Not Made
+
+A request of kind `legal_demand` or `sealed_or_expunged` MUST NOT be resolved
+without having been escalated first. A suspected sealed or expunged record MUST
+NOT be declined.
+
+#### Scenario: An unescalated legal demand cannot be resolved
+
+- **WHEN** a `legal_demand` request is set to `action_taken` with `escalated_at` null
+- **THEN** the database rejects it and names the Executive Director as the route
+
+#### Scenario: A legal demand can be escalated
+
+- **WHEN** a `legal_demand` request is set to `escalated` with `escalated_at` and `escalated_to`
+- **THEN** the write succeeds
+
+#### Scenario: A suspected sealed record cannot be declined
+
+- **WHEN** a `sealed_or_expunged` request is set to `declined`, even after escalation
+- **THEN** the database rejects it
+
+### Requirement: Suppression Removes A Subject From The Public Surface
+
+An active suppression MUST remove its subject from every render view.
+
+#### Scenario: A suppressed subject stops rendering
+
+- **WHEN** a subject with published claims is suppressed
+- **THEN** `render.published_claim` returns no rows for that subject
+
+#### Scenario: The invariant self-check confirms no suppressed subject is reachable
+
+- **WHEN** `public.assert_suppression_invariant()` is called with an active suppression in place
+- **THEN** it returns zero rows
+
+### Requirement: Suppression Is Anchored To The Upstream Record Key
+
+Applying a suppression MUST record the `(source_id, source_record_key)` pairs
+behind the subject, so that suppression does not depend on the durability of a
+canonical ID mapping.
+
+#### Scenario: Source keys are captured when a suppression is applied
+
+- **WHEN** a subject with claims is suppressed
+- **THEN** `suppression_source_key` holds one row per distinct source and source record key behind that subject
+
+### Requirement: A Re-Import Cannot Reintroduce A Suppressed Record
+
+The ingestion pipeline MUST NOT be able to overwrite, delete, or reintroduce a
+suppressed record, whether or not the canonical ID from the original
+suppression survived.
+
+#### Scenario: Re-import under the same canonical ID is refused
+
+- **WHEN** the ingestion role writes a claim for a suppressed subject
+- **THEN** the database rejects it and names the active suppression
+
+#### Scenario: Re-import of the same upstream row under a NEW canonical ID is refused
+
+- **WHEN** the ingestion role writes a claim whose subject ID has no suppression of its own, but whose `(source_id, source_record_key)` is covered by an active suppression
+- **THEN** the database rejects it and names the active suppression
+
+#### Scenario: In-place update of a suppressed entity row is refused
+
+- **WHEN** the ingestion role updates `public.agency` or `public.officers` for a suppressed row
+- **THEN** the database rejects it
+
+#### Scenario: Delete-and-recreate of a suppressed entity row is refused
+
+- **WHEN** the ingestion role deletes a suppressed row from `public.agency` or `public.officers`
+- **THEN** the database rejects it
+
+#### Scenario: The subject stays off the render surface after a re-run attempt
+
+- **WHEN** a re-import attempt against a suppressed subject has been refused
+- **THEN** the subject is still absent from `render.published_claim` and the invariant self-check returns zero rows
+
+### Requirement: The Ingestion Role Cannot Change Suppression State
+
+The ingestion role MUST hold SELECT and nothing else on the suppression tables,
+so that suppression cannot be undone by the pipeline even if a trigger is later
+removed.
+
+#### Scenario: The ingestion role cannot lift or delete a suppression
+
+- **WHEN** the ingestion role attempts to update or delete `subject_suppression`
+- **THEN** the database rejects it with permission denied
+
+#### Scenario: The ingestion role cannot forge a source key
+
+- **WHEN** the ingestion role attempts to insert into `suppression_source_key`
+- **THEN** the database rejects it with permission denied
+
+#### Scenario: The ingestion role can read suppression state
+
+- **WHEN** the ingestion role calls `is_source_key_suppressed`
+- **THEN** it returns the active suppression id, so the planner can skip the record
+
+#### Scenario: Re-granting write access fails the build
+
+- **WHEN** a later migration grants the ingestion role UPDATE on `subject_suppression`
+- **THEN** `assert_suppression_invariant()` returns `intake_can_modify_suppression`
+
+### Requirement: Suppression Actions Are Logged And Cannot Be Erased
+
+Applying and lifting a suppression MUST write an append-only audit event naming
+the actor, reason, and basis. A suppression MUST NOT be deletable, and its
+reason and subject MUST NOT be rewritable.
+
+#### Scenario: Applying a suppression writes an audit event
+
+- **WHEN** a suppression is applied
+- **THEN** `publication_event` holds a subject-level row with `to_status` `blocked`, the reason code, the basis, and the acting actor
+
+#### Scenario: A suppression cannot be deleted
+
+- **WHEN** a delete is attempted against `subject_suppression`
+- **THEN** the database rejects it and directs the caller to lift it instead
+
+#### Scenario: The reason for a suppression cannot be rewritten
+
+- **WHEN** an update attempts to change `reason_code`, the subject, or who applied it
+- **THEN** the database rejects it as lift-fields-only
+
+#### Scenario: Lifting requires a stated basis
+
+- **WHEN** a suppression is lifted without `lift_note`
+- **THEN** the database rejects it
+
+### Requirement: Lifting A Suppression Does Not Republish
+
+Lifting a suppression MUST return the subject's published claims to `staged`.
+
+#### Scenario: A lifted subject does not return to the public surface
+
+- **WHEN** a suppression is lifted with a stated basis
+- **THEN** the subject's claims are `staged`, the subject is absent from `render.published_claim`, and a `staged` audit event names the lifting actor and the basis
+
+### Requirement: The Public Corrections Log Does Not Re-Identify People
+
+The public corrections log MUST name agencies, MUST NOT disclose the subject of
+a person-level action, and MUST NOT expose requester identity.
+
+#### Scenario: An agency correction is named
+
+- **WHEN** an agency record is withheld
+- **THEN** `render.corrections_log` shows the agency subject id, the action, and a plain-language reason
+
+#### Scenario: A person-level action is not attributed
+
+- **WHEN** a person record is withheld
+- **THEN** `render.corrections_log` shows the action and reason with a null subject id
+
+#### Scenario: Requester identity is not exposed
+
+- **WHEN** the corrections log view and the page role's grants are inspected
+- **THEN** no requester column is present and the page role holds no privilege on `correction_request`

--- a/openspec/changes/2026-08-24-corrections-and-takedown/tasks.md
+++ b/openspec/changes/2026-08-24-corrections-and-takedown/tasks.md
@@ -1,0 +1,86 @@
+# Tasks
+
+## 1. Schema
+
+- [x] Add `supabase/migrations/20260824190000_corrections_and_takedown.sql` as a
+      purely additive migration. No existing table is altered or dropped.
+- [x] Intake: `correction_request` with `correction_request_kind`,
+      `correction_request_channel`, and `correction_request_disposition` enums;
+      substance immutable after insert; not deletable; resolution must name a
+      decider.
+- [x] Boundary: `enforce_legal_demand_routing` refuses to resolve a
+      `legal_demand` or `sealed_or_expunged` request that was not escalated, and
+      refuses to decline a suspected sealed record at all.
+- [x] Re-import durability: `suppression_source_key`, populated by trigger at
+      suppression time; `is_subject_suppressed`, `is_id_suppressed`, and
+      `is_source_key_suppressed` lookups; `claim_suppression_guard` checking
+      both the canonical ID and the upstream record key.
+- [x] Legacy entity guard: `agency_suppression_guard` and
+      `officers_suppression_guard` refuse UPDATE and DELETE on a suppressed row.
+- [x] Audit: `subject_suppression` DELETE refused; UPDATE restricted to the lift
+      fields, once, with a required `lift_note`; apply and lift both write
+      `publication_event`.
+- [x] `restage_claims_on_lift` returns claims to `staged` on lift rather than
+      restoring the prior publication status.
+- [x] Least-privilege `intake_writer` role: DML on data tables, SELECT-only on
+      `subject_suppression`, `suppression_source_key`, `publication_event`, and
+      `source_retrieval`.
+- [x] Public surface: `render.corrections_log` and
+      `render.corrections_reason_label`, granted explicitly to `page_renderer`.
+- [x] All primary keys are `text` with no `DEFAULT`, per the repo ID policy. The
+      only generated ID is `publication_event.event_id`, which keeps the
+      append-only-log exemption stated in the provenance migration.
+
+## 2. Enforcement
+
+- [x] `public.assert_suppression_invariant()` returns violations for: the
+      ingestion role holding write access to suppression state or to the audit
+      trail; an actively-suppressed subject reachable through a render view;
+      requester identity exposed to the page role; a legal demand resolved
+      without escalation.
+- [x] `assert_provenance_invariant()` redefined to widen its render-view
+      allowlist to include `corrections_log`. Its other four checks are
+      unchanged and the function is restated in full so the diff shows that.
+- [x] `scripts/assert-suppression-invariant.ts` and the `assert:suppression`
+      npm script, mirroring `assert:provenance`, for CI.
+
+## 3. Pipeline
+
+- [x] `src/cli/database/suppression.ts` reads active suppressions through the
+      same role that cannot write them.
+- [x] `classifyDatabaseOperations` reads suppression state itself rather than
+      accepting it as a parameter, and demotes a suppressed row from `update` to
+      `read`, so a honoured takedown costs one skipped record rather than an
+      aborted import.
+
+## 4. Validation
+
+- [x] `test/schema/corrections-takedown.test.ts` — 26 tests against a real
+      Postgres, covering each clause of the issue's done-when: suppression takes
+      effect, survives a re-import under both the same and a new canonical ID,
+      and is logged. Skips when `TEST_DATABASE_URL` is absent.
+- [x] `test:schema` npm script runs the schema suites with
+      `--no-file-parallelism`. Both suites reset the `public` schema, so running
+      them concurrently against one database is a race.
+- [x] Verified 68/68 schema tests pass against PostgreSQL 18.4 from a clean
+      database.
+- [x] Verified `assert_suppression_invariant()` is not vacuous: granting the
+      ingestion role UPDATE on `subject_suppression` makes it exit 1 with
+      `intake_can_modify_suppression`.
+- [x] `npx tsc -p tsconfig.json --noEmit` clean.
+- [ ] Verify against a real `supabase db reset` database, not just the
+      fixture, once PR #60 is merged. Tracked with the same verification as
+      INS-30.
+
+## 5. Follow-ups filed, not done here
+
+- [ ] Source-key plumbing for `public.agency` and `public.officers`. Those
+      tables carry no `source_record_key`, so re-identification cannot be
+      blocked in the database for the legacy corpus that renders the 132,109
+      live personnel pages. Needs source record keys threaded through
+      `ImportRows`.
+- [ ] Surface suppressed-record skips in the load's change diff.
+- [ ] Public `/corrections/` page on policeconduct.org, reading
+      `render.corrections_log`. Blocked until this migration is applied to the
+      real database; a page querying a view that does not exist yet would fail
+      the site build.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "setup": "bash scripts/bootstrap-dev.sh",
     "doctor": "bash scripts/bootstrap-dev.sh --check",
     "assert:provenance": "tsx scripts/assert-provenance-invariant.ts",
+    "assert:suppression": "tsx scripts/assert-suppression-invariant.ts",
     "cli": "tsx src/cli/index.ts",
     "link-seed": "bash scripts/link-seed.sh",
     "format": "prettier --write \"**/*.{json,md,ts,yml,yaml}\"",
@@ -35,6 +36,7 @@
     "pretypecheck": "npm run generate:envelope-types",
     "test": "vitest run",
     "test:vitest": "vitest run",
+    "test:schema": "vitest run --no-file-parallelism test/schema",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "validate": "npm run format:check && npm run lint && npm run test:vitest && npm run build && npm run openspec:validate"
   },

--- a/scripts/assert-suppression-invariant.ts
+++ b/scripts/assert-suppression-invariant.ts
@@ -1,0 +1,54 @@
+/**
+ * Fails the build if the corrections/takedown invariant has been weakened.
+ *
+ * The counterpart to assert-provenance-invariant.ts. This runs
+ * public.assert_suppression_invariant() against a live database and exits
+ * non-zero on any violation. The findings it exists to catch:
+ *
+ *   - a later migration re-granting the ingestion role write access to the
+ *     suppression tables, typically via a convenient
+ *     `grant all on all tables in schema public`;
+ *   - an actively-suppressed subject that is reachable through a render view,
+ *     which is a takedown that is not actually in effect;
+ *   - requester identity leaking into the public corrections log;
+ *   - a legal demand resolved without escalation.
+ *
+ * Run this after `supabase db reset` and after every migration in CI. A
+ * suppression invariant that is only checked by the migration that created it
+ * decays the moment someone writes the next migration.
+ *
+ *   DATABASE_URL=postgres://... npm run assert:suppression
+ */
+
+import { Client } from "pg";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+
+if (!DATABASE_URL) {
+  console.error("assert:suppression requires DATABASE_URL");
+  process.exit(2);
+}
+
+const client = new Client({ connectionString: DATABASE_URL });
+await client.connect();
+
+try {
+  const { rows } = await client.query<{ violation: string; detail: string }>(
+    "select violation, detail from public.assert_suppression_invariant()",
+  );
+
+  if (rows.length === 0) {
+    console.log("suppression invariant intact");
+    process.exit(0);
+  }
+
+  console.error(
+    `suppression invariant VIOLATED (${rows.length} finding${rows.length === 1 ? "" : "s"}):`,
+  );
+  for (const row of rows) {
+    console.error(`  ${row.violation}: ${row.detail}`);
+  }
+  process.exit(1);
+} finally {
+  await client.end();
+}

--- a/src/cli/database/suppression.ts
+++ b/src/cli/database/suppression.ts
@@ -1,0 +1,47 @@
+import type { DatabaseClient } from "./index.js";
+
+/**
+ * Reading suppression state during import planning.
+ *
+ * The database refuses writes to a suppressed subject outright (see
+ * supabase/migrations/20260824190000_corrections_and_takedown.sql). That
+ * refusal is the guarantee, but it is a backstop: if the planner did not know
+ * about suppressions, every import after a takedown would abort on the first
+ * suppressed row. Intake reads the same state and plans around it, so a
+ * honoured takedown costs one skipped record rather than a broken pipeline.
+ *
+ * `intake_writer` is granted SELECT and nothing else on these tables, so this
+ * read works and the corresponding write does not.
+ */
+
+function rowsFromResult(
+  result: { rows?: Record<string, unknown>[] } | unknown,
+): Record<string, unknown>[] {
+  return typeof result === "object" &&
+    result !== null &&
+    "rows" in result &&
+    Array.isArray(result.rows)
+    ? result.rows
+    : [];
+}
+
+/**
+ * Canonical IDs under an active suppression, regardless of subject_type.
+ *
+ * Type-agnostic on purpose: canonical IDs are cuid2 and globally unique, so a
+ * suppression filed against subject_type='person' must still stop a write that
+ * calls the same ID an 'officer'.
+ */
+export async function readActiveSuppressedIds(
+  client: DatabaseClient,
+): Promise<ReadonlySet<string>> {
+  const rows = rowsFromResult(
+    await client.query(
+      `select distinct subject_id
+       from public.subject_suppression
+       where lifted_at is null`,
+    ),
+  );
+
+  return new Set(rows.map((row) => String(row.subject_id)));
+}

--- a/src/cli/import/artifacts/classify-database-operations.ts
+++ b/src/cli/import/artifacts/classify-database-operations.ts
@@ -5,6 +5,7 @@ import {
 } from "../../database/entities.js";
 import { readLocationPathAliasByPath } from "../../database/location-paths.js";
 import type { SupportedTableName } from "../../database/schema.js";
+import { readActiveSuppressedIds } from "../../database/suppression.js";
 import type { DatabaseRowOperations } from "./operations.js";
 import type { ImportRows, LocationPathRow } from "./transform.js";
 
@@ -22,6 +23,11 @@ export async function classifyDatabaseOperations(
   databaseLocationPaths: readonly LocationPathRow[] = [],
   preparedOperations?: DatabaseRowOperations,
 ): Promise<DatabaseRowOperations> {
+  // Read suppression state here rather than accepting it as a parameter: a
+  // caller that forgets to pass it would plan writes against suppressed
+  // records, and the resulting import would abort on the database guard
+  // instead of skipping the record. There is no way to opt out of this read.
+  const suppressedIds = await readActiveSuppressedIds(client);
   const operations: DatabaseRowOperations = preparedOperations ?? {
     locationPaths: {},
     locationPathGeometries: {},
@@ -104,7 +110,8 @@ export async function classifyDatabaseOperations(
     }
     const exists = await rowExists(client, "public.agency", agency.id);
     operations.agencies[agency.id] = exists
-      ? (rows.ownedColumns.agencies[agency.id] ?? []).length > 0
+      ? (rows.ownedColumns.agencies[agency.id] ?? []).length > 0 &&
+        !suppressedIds.has(agency.id)
         ? "update"
         : "read"
       : "create";
@@ -113,7 +120,8 @@ export async function classifyDatabaseOperations(
   for (const officer of rows.officers) {
     const exists = await rowExists(client, "public.officers", officer.id);
     operations.officers[officer.id] = exists
-      ? (rows.ownedColumns.officers[officer.id] ?? []).length > 0
+      ? (rows.ownedColumns.officers[officer.id] ?? []).length > 0 &&
+        !suppressedIds.has(officer.id)
         ? "update"
         : "read"
       : "create";
@@ -126,7 +134,10 @@ export async function classifyDatabaseOperations(
       agencyOfficer.id,
     );
     operations.agencyOfficers[agencyOfficer.id] = exists
-      ? (rows.ownedColumns.agencyOfficers[agencyOfficer.id] ?? []).length > 0
+      ? (rows.ownedColumns.agencyOfficers[agencyOfficer.id] ?? []).length > 0 &&
+        !suppressedIds.has(agencyOfficer.id) &&
+        !suppressedIds.has(agencyOfficer.personnel_id) &&
+        !suppressedIds.has(agencyOfficer.agency_id)
         ? "update"
         : "read"
       : "create";

--- a/supabase/migrations/20260824190000_corrections_and_takedown.sql
+++ b/supabase/migrations/20260824190000_corrections_and_takedown.sql
@@ -1,0 +1,879 @@
+-- Corrections and takedown mechanics with an audit trail (INS-9).
+--
+-- Builds on 20260824170000_provenance_structural_invariant.sql, which already
+-- established `subject_suppression` (an active row removes a subject from every
+-- render view) and `publication_event` (append-only status audit). Those give
+-- us suppression STATE. They do not give us:
+--
+--   1. An intake path. Correction requests and takedown demands arrive as
+--      email, forms, and attorney letters and currently land nowhere durable.
+--
+--   2. Durability against the ingestion pipeline. Today the loader connects
+--      with full rights on `public`. Nothing stops a re-import from updating
+--      `lifted_at` or deleting the suppression row outright. "Honored Tuesday,
+--      undone by Wednesday's re-import" is currently reachable.
+--
+--   3. Durability against IDENTITY CHURN, which is the subtler half. Intake
+--      maps source record keys to canonical cuid2 IDs through an on-disk YAML
+--      ledger (src/cli/state/source-name-to-canonical-id). `subject_suppression`
+--      is keyed on the canonical ID. If that ledger is regenerated, lost, or
+--      diverges, a re-import assigns a NEW canonical ID to the SAME upstream
+--      record. The suppression row survives, still points at the old ID, and
+--      protects nothing. The record comes back under a new ID and every
+--      suppression check passes.
+--
+--      This is why suppression is captured at the SOURCE KEY level here, not
+--      only the canonical-ID level. A suppression records which upstream rows
+--      produced the subject, so re-identification does not launder it.
+--
+--   4. A public corrections log.
+--
+-- Boundary (INS-9): this migration builds the mechanism. It does not decide
+-- what gets taken down. Legal demands are structurally forbidden from being
+-- resolved here -- see `enforce_legal_demand_routing` below.
+--
+-- ID policy: per openspec/config.yaml the database MUST NEVER generate durable
+-- IDs. `correction_request` and `subject_suppression` IDs are assigned by the
+-- caller. `publication_event` rows are an append-only log, not durable
+-- entities, and keep the generated-ID exemption established in the provenance
+-- migration.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 1. Intake: correction requests and takedown demands
+-- ---------------------------------------------------------------------------
+
+-- What arrived. Kept distinct because the routing rules differ, not for
+-- reporting convenience: `legal_demand` is barred from being resolved by
+-- anyone but the Executive Director, and `sealed_or_expunged` is barred from
+-- being declined at all.
+create type public.correction_request_kind as enum (
+    'correction',            -- "this fact is wrong" -- from anyone
+    'removal_request',       -- "take this down" -- from a member of the public
+    'legal_demand',          -- attorney letter, cease and desist, court order
+    'data_subject_request',  -- statutory access/erasure request
+    'source_withdrawal',     -- the publisher retracted or corrected the source
+    'sealed_or_expunged',    -- record may be sealed or expunged
+    'internal_finding'       -- we found the error ourselves
+);
+
+-- How it reached us. Recorded because a demand served by a process server and
+-- a note typed into a web form carry different obligations, and because we
+-- must be able to show the intake channel if the handling is ever questioned.
+create type public.correction_request_channel as enum (
+    'web_form',
+    'email',
+    'postal_mail',
+    'phone',
+    'legal_service',
+    'source_publisher',
+    'internal'
+);
+
+create type public.correction_request_disposition as enum (
+    'received',      -- logged, untouched. The only state intake may write.
+    'escalated',     -- routed to the Executive Director. Terminal for engineering.
+    'action_taken',  -- a suppression or correction was applied under a named decision
+    'declined',      -- a named decider chose not to act
+    'withdrawn'      -- the requester withdrew it
+);
+
+create table public.correction_request (
+    request_id text primary key,
+
+    received_at timestamp with time zone not null default timezone('utc'::text, now()),
+    channel public.correction_request_channel not null,
+    request_kind public.correction_request_kind not null,
+
+    -- The requester's own words, unedited. Immutable after insert (trigger
+    -- below). If we ever have to show what was actually asked of us, a
+    -- paraphrase is worthless.
+    request_text text not null,
+
+    -- Requester identity. Personal data: never reaches a render view, and the
+    -- corrections-log view is asserted not to expose it.
+    requester_name text,
+    requester_contact text,
+    requester_role text,
+
+    -- What the requester says it is about. Nullable on purpose -- a requester
+    -- will often send a URL or a name, not a canonical ID, and forcing a
+    -- resolution at intake time invites a wrong guess about which human the
+    -- request concerns.
+    subject_type text,
+    subject_id text,
+    subject_hint text,
+
+    disposition public.correction_request_disposition not null default 'received',
+
+    escalated_at timestamp with time zone,
+    escalated_to text,
+
+    decided_at timestamp with time zone,
+    decided_by text,
+    decision_note text,
+
+    -- Set when acting on this request produced a suppression.
+    resulting_suppression_id text,
+
+    -- Whether this request's outcome appears in the public corrections log.
+    -- Default false: publishing that a named person asked to be removed
+    -- re-publishes the association the removal was meant to end.
+    publish_in_log boolean not null default false,
+
+    created_at timestamp with time zone not null default timezone('utc'::text, now()),
+    updated_at timestamp with time zone not null default timezone('utc'::text, now()),
+
+    constraint correction_request_escalation_complete check (
+        (escalated_at is null and escalated_to is null)
+        or (escalated_at is not null and escalated_to is not null)
+    ),
+    constraint correction_request_decision_complete check (
+        (decided_at is null and decided_by is null)
+        or (decided_at is not null and decided_by is not null)
+    ),
+    -- A resolved request must name who resolved it. "It got closed" with no
+    -- attributable decider is the state we are specifically trying to avoid.
+    constraint correction_request_resolution_attributed check (
+        disposition not in ('action_taken', 'declined')
+        or (decided_at is not null and decided_by is not null)
+    )
+);
+
+comment on table public.correction_request is
+'Intake ledger for correction requests and takedown demands. Append-only in its substance: request_text and requester identity are immutable after insert. INS-9 boundary -- engineering logs and escalates; it does not decide.';
+
+create index correction_request_open_idx
+on public.correction_request (received_at)
+where disposition = 'received';
+
+create index correction_request_subject_idx
+on public.correction_request (subject_type, subject_id)
+where subject_id is not null;
+
+create index correction_request_kind_idx
+on public.correction_request (request_kind, disposition);
+
+-- The substance of a request cannot be edited after it arrives. Disposition,
+-- escalation, decision, and linkage fields remain mutable; what the requester
+-- said and who they are do not.
+create or replace function public.enforce_correction_request_immutable_substance()
+returns trigger
+language plpgsql
+as $$
+begin
+    if new.request_text is distinct from old.request_text
+        or new.requester_name is distinct from old.requester_name
+        or new.requester_contact is distinct from old.requester_contact
+        or new.requester_role is distinct from old.requester_role
+        or new.channel is distinct from old.channel
+        or new.request_kind is distinct from old.request_kind
+        or new.received_at is distinct from old.received_at
+    then
+        raise exception
+            'correction_request %: request substance is immutable after intake',
+            old.request_id
+            using errcode = 'restrict_violation';
+    end if;
+
+    new.updated_at := timezone('utc'::text, now());
+    return new;
+end;
+$$;
+
+create trigger correction_request_immutable_substance
+before update on public.correction_request
+for each row execute function public.enforce_correction_request_immutable_substance();
+
+create or replace function public.reject_correction_request_delete()
+returns trigger
+language plpgsql
+as $$
+begin
+    raise exception
+        'correction_request is not deletable: attempted delete on request_id=%',
+        old.request_id
+        using errcode = 'restrict_violation';
+end;
+$$;
+
+create trigger correction_request_no_delete
+before delete on public.correction_request
+for each row execute function public.reject_correction_request_delete();
+
+-- The INS-9 boundary, expressed as a constraint rather than a paragraph in a
+-- runbook.
+--
+-- A legal demand may go exactly one place: escalated. It cannot be marked
+-- action_taken or declined here, because deciding what a legal demand requires
+-- is a legal determination and this role does not make those. Reaching
+-- 'action_taken' or 'declined' requires that it was escalated first AND that a
+-- decider is named -- so the record shows a human made the call.
+--
+-- A suspected sealed or expunged record may never be declined. If we are wrong
+-- about it being sealed, we have published sealed material.
+create or replace function public.enforce_legal_demand_routing()
+returns trigger
+language plpgsql
+as $$
+begin
+    if new.request_kind in ('legal_demand', 'sealed_or_expunged')
+        and new.disposition in ('action_taken', 'declined')
+        and new.escalated_at is null
+    then
+        raise exception
+            'request % is a % and must be escalated before it can be resolved; route it to the Executive Director untouched',
+            new.request_id, new.request_kind
+            using errcode = 'restrict_violation';
+    end if;
+
+    if new.request_kind = 'sealed_or_expunged' and new.disposition = 'declined' then
+        raise exception
+            'request %: a suspected sealed or expunged record cannot be declined',
+            new.request_id
+            using errcode = 'restrict_violation';
+    end if;
+
+    return new;
+end;
+$$;
+
+create trigger correction_request_legal_routing
+before insert or update on public.correction_request
+for each row execute function public.enforce_legal_demand_routing();
+
+-- ---------------------------------------------------------------------------
+-- 2. Suppression that survives a re-import
+-- ---------------------------------------------------------------------------
+
+-- Which upstream rows are covered by a suppression.
+--
+-- This is the answer to identity churn. `subject_suppression` protects a
+-- canonical ID; this table protects the SOURCE RECORD that produced it. A
+-- re-import that assigns a fresh canonical ID to the same upstream row still
+-- collides with these keys, because the source's own record key does not
+-- change when our ledger does.
+create table public.suppression_source_key (
+    suppression_id text not null
+        references public.subject_suppression (suppression_id) on delete restrict,
+    source_id text not null references public.source (source_id) on delete restrict,
+    source_record_key text not null,
+    captured_at timestamp with time zone not null default timezone('utc'::text, now()),
+
+    primary key (suppression_id, source_id, source_record_key)
+);
+
+comment on table public.suppression_source_key is
+'Upstream (source, record key) pairs covered by a suppression. Suppression keyed only on our canonical ID is defeated by re-identification; this is keyed on the source''s own identifier, which a re-import cannot change.';
+
+create index suppression_source_key_lookup_idx
+on public.suppression_source_key (source_id, source_record_key);
+
+-- Capture the source keys automatically when a suppression is applied.
+--
+-- Doing this by trigger rather than by convention matters: whoever honours a
+-- takedown at 11pm is not going to remember to also enumerate the upstream
+-- record keys, and a suppression that missed them looks identical to one that
+-- did not until the next import quietly resurrects the record.
+create or replace function public.capture_suppression_source_keys()
+returns trigger
+language plpgsql
+as $$
+begin
+    insert into public.suppression_source_key
+        (suppression_id, source_id, source_record_key)
+    select distinct new.suppression_id, r.source_id, c.source_record_key
+    from public.claim c
+        join public.source_retrieval r on r.retrieval_id = c.retrieval_id
+    where c.subject_type = new.subject_type
+        and c.subject_id = new.subject_id
+    on conflict do nothing;
+
+    return null;
+end;
+$$;
+
+comment on function public.capture_suppression_source_keys() is
+'Records the upstream record keys behind a subject at the moment it is suppressed, so a later re-import cannot reintroduce it under a new canonical ID.';
+
+create trigger subject_suppression_capture_source_keys
+after insert on public.subject_suppression
+for each row execute function public.capture_suppression_source_keys();
+
+-- Is this subject under an active suppression?
+create or replace function public.is_subject_suppressed(
+    p_subject_type text,
+    p_subject_id text
+)
+returns text
+language sql
+stable
+as $$
+    select sup.suppression_id
+    from public.subject_suppression sup
+    where sup.subject_type = p_subject_type
+        and sup.subject_id = p_subject_id
+        and sup.lifted_at is null
+    limit 1;
+$$;
+
+comment on function public.is_subject_suppressed(text, text) is
+'Returns the active suppression_id for a subject, or null. Returns the id rather than a boolean so callers can name the suppression in their error message.';
+
+-- Suppression lookup by canonical ID alone, ignoring subject_type.
+--
+-- Deliberately over-broad. Canonical IDs are cuid2 and globally unique, so a
+-- match is a match. A suppression filed against subject_type='person' must
+-- still stop a write that calls the same ID an 'officer'; a type mismatch is
+-- exactly the kind of near-miss that would otherwise let a record through.
+create or replace function public.is_id_suppressed(p_subject_id text)
+returns text
+language sql
+stable
+as $$
+    select sup.suppression_id
+    from public.subject_suppression sup
+    where sup.subject_id = p_subject_id
+        and sup.lifted_at is null
+    limit 1;
+$$;
+
+-- Is this UPSTREAM record covered by an active suppression, whatever canonical
+-- ID it is being mapped to this time?
+create or replace function public.is_source_key_suppressed(
+    p_source_id text,
+    p_source_record_key text
+)
+returns text
+language sql
+stable
+as $$
+    select ssk.suppression_id
+    from public.suppression_source_key ssk
+        join public.subject_suppression sup
+            on sup.suppression_id = ssk.suppression_id
+    where ssk.source_id = p_source_id
+        and ssk.source_record_key = p_source_record_key
+        and sup.lifted_at is null
+    limit 1;
+$$;
+
+comment on function public.is_source_key_suppressed(text, text) is
+'The re-import guard. Answers "is this upstream row suppressed" without reference to any canonical ID, so a regenerated ID mapping cannot launder a takedown.';
+
+-- The Wednesday guard.
+--
+-- Refuses to write a claim that is under suppression by EITHER route: the
+-- subject's canonical ID, or the upstream record key that produced it. A
+-- re-import hits this whether or not the canonical ID survived.
+--
+-- This raises rather than silently dropping the row. A loader that is trying
+-- to reintroduce suppressed material should stop and be looked at, not skip a
+-- row into a log nobody reads. Intake pre-filters suppressed subjects so this
+-- is a backstop, not the routine path.
+create or replace function public.enforce_claim_not_suppressed()
+returns trigger
+language plpgsql
+as $$
+declare
+    blocking text;
+    claim_source text;
+begin
+    blocking := public.is_id_suppressed(new.subject_id);
+
+    if blocking is null then
+        select r.source_id into claim_source
+        from public.source_retrieval r
+        where r.retrieval_id = new.retrieval_id;
+
+        blocking := public.is_source_key_suppressed(claim_source, new.source_record_key);
+    end if;
+
+    if blocking is not null then
+        raise exception
+            'claim %: subject %/% is under active suppression % (source record key %); a suppressed record may not be rewritten by an import',
+            new.claim_id, new.subject_type, new.subject_id, blocking, new.source_record_key
+            using errcode = 'restrict_violation',
+                  hint = 'Lift the suppression through the corrections process, or exclude this record from the import.';
+    end if;
+
+    return new;
+end;
+$$;
+
+create trigger claim_suppression_guard
+before insert or update on public.claim
+for each row execute function public.enforce_claim_not_suppressed();
+
+-- The same guard on the pre-provenance entity tables that intake still writes
+-- directly. `public.agency` and `public.officers` predate the claim model and
+-- the loader updates their columns in place; without this, a re-import
+-- silently overwrites the contents of a record that is under legal hold.
+create or replace function public.enforce_entity_not_suppressed()
+returns trigger
+language plpgsql
+as $$
+declare
+    blocking text;
+begin
+    blocking := public.is_id_suppressed(
+        case when tg_op = 'DELETE' then old.id else new.id end
+    );
+
+    if blocking is not null then
+        raise exception
+            'table %: row % is under active suppression %; % refused',
+            tg_table_name,
+            case when tg_op = 'DELETE' then old.id else new.id end,
+            blocking,
+            tg_op
+            using errcode = 'restrict_violation',
+                  hint = 'Lift the suppression through the corrections process before modifying this row.';
+    end if;
+
+    return case when tg_op = 'DELETE' then old else new end;
+end;
+$$;
+
+create trigger agency_suppression_guard
+before update or delete on public.agency
+for each row execute function public.enforce_entity_not_suppressed();
+
+create trigger officers_suppression_guard
+before update or delete on public.officers
+for each row execute function public.enforce_entity_not_suppressed();
+
+-- ---------------------------------------------------------------------------
+-- 3. Suppression is applied and lifted under audit, never deleted
+-- ---------------------------------------------------------------------------
+
+-- A suppression row is never removed. Deleting one destroys the evidence that
+-- we honoured a takedown, which is the record we would most need if the
+-- handling were ever challenged.
+create or replace function public.reject_subject_suppression_delete()
+returns trigger
+language plpgsql
+as $$
+begin
+    raise exception
+        'subject_suppression is not deletable: lift it instead (suppression_id=%)',
+        old.suppression_id
+        using errcode = 'restrict_violation';
+end;
+$$;
+
+create trigger subject_suppression_no_delete
+before delete on public.subject_suppression
+for each row execute function public.reject_subject_suppression_delete();
+
+-- The only legal update to a suppression is lifting it, once, with a reason.
+-- Editing why or against whom a suppression was filed would make the audit
+-- trail a narrative rather than a record.
+create or replace function public.enforce_subject_suppression_lift_only()
+returns trigger
+language plpgsql
+as $$
+begin
+    if new.subject_type is distinct from old.subject_type
+        or new.subject_id is distinct from old.subject_id
+        or new.reason_code is distinct from old.reason_code
+        or new.reason_note is distinct from old.reason_note
+        or new.requested_by is distinct from old.requested_by
+        or new.applied_by is distinct from old.applied_by
+        or new.applied_at is distinct from old.applied_at
+    then
+        raise exception
+            'suppression %: only the lift fields may be updated',
+            old.suppression_id
+            using errcode = 'restrict_violation';
+    end if;
+
+    if old.lifted_at is not null then
+        raise exception
+            'suppression % is already lifted and cannot be re-lifted or re-applied; file a new suppression',
+            old.suppression_id
+            using errcode = 'restrict_violation';
+    end if;
+
+    if new.lifted_at is not null
+        and coalesce(btrim(new.lift_note), '') = ''
+    then
+        raise exception
+            'suppression %: lifting requires lift_note stating the basis',
+            old.suppression_id
+            using errcode = 'restrict_violation';
+    end if;
+
+    return new;
+end;
+$$;
+
+create trigger subject_suppression_lift_only
+before update on public.subject_suppression
+for each row execute function public.enforce_subject_suppression_lift_only();
+
+-- Suppression apply/lift lands in the same append-only log as claim status
+-- transitions, so "what happened to this subject" is one query rather than a
+-- reconciliation of two tables.
+create or replace function public.record_suppression_event()
+returns trigger
+language plpgsql
+as $$
+declare
+    acting text;
+begin
+    if tg_op = 'UPDATE' and new.lifted_at is null then
+        return null;
+    end if;
+
+    acting := coalesce(
+        nullif(current_setting('intake.actor', true), ''),
+        case when tg_op = 'INSERT' then new.applied_by else new.lifted_by end,
+        'unattributed:' || session_user
+    );
+
+    insert into public.publication_event (
+        event_id, subject_type, subject_id, claim_id,
+        from_status, to_status, reason_code, reason_note, actor
+    )
+    values (
+        'pev_' || encode(gen_random_bytes(12), 'hex'),
+        new.subject_type,
+        new.subject_id,
+        null,
+        case when tg_op = 'UPDATE' then 'blocked'::public.publication_status else null end,
+        case when tg_op = 'INSERT' then 'blocked'::public.publication_status
+             else 'staged'::public.publication_status end,
+        new.reason_code,
+        case when tg_op = 'INSERT' then new.reason_note else new.lift_note end,
+        acting
+    );
+
+    return null;
+end;
+$$;
+
+comment on function public.record_suppression_event() is
+'Writes suppression apply and lift into publication_event. A lift records to_status=staged, never published: see restage_claims_on_lift.';
+
+create trigger subject_suppression_audit
+after insert or update on public.subject_suppression
+for each row execute function public.record_suppression_event();
+
+-- Lifting a suppression returns the subject to `staged`. It does not restore
+-- whatever publication status the claims held before.
+--
+-- This is deliberate and it is the conservative direction. A suppression is
+-- lifted for many reasons -- the dispute was resolved, the wrong subject was
+-- suppressed, the hold expired -- and none of them are the same decision as
+-- "this is fit to publish". Making republication a separate, separately
+-- audited act means an accidental lift cannot re-expose a page.
+create or replace function public.restage_claims_on_lift()
+returns trigger
+language plpgsql
+as $$
+begin
+    if new.lifted_at is null then
+        return null;
+    end if;
+
+    perform set_config(
+        'intake.reason_note',
+        'restaged on lift of suppression ' || new.suppression_id,
+        true
+    );
+
+    update public.claim
+    set publication_status = 'staged'
+    where subject_type = new.subject_type
+        and subject_id = new.subject_id
+        and publication_status = 'published';
+
+    return null;
+end;
+$$;
+
+create trigger subject_suppression_restage
+after update on public.subject_suppression
+for each row execute function public.restage_claims_on_lift();
+
+-- ---------------------------------------------------------------------------
+-- 4. Least-privilege ingestion role
+-- ---------------------------------------------------------------------------
+
+-- The triggers above stop an accidental un-suppression. This stops a
+-- deliberate one, and it is the half that does not depend on a future
+-- migration leaving the triggers in place: the ingestion role has no
+-- privilege on the suppression tables at all.
+--
+-- Loaders must connect as `intake_writer`. A loader running as the database
+-- owner is outside this guarantee, which is why assert_suppression_invariant()
+-- checks the grants rather than trusting the connection string.
+do $$
+begin
+    if not exists (select 1 from pg_roles where rolname = 'intake_writer') then
+        create role intake_writer nologin;
+    end if;
+end;
+$$;
+
+grant usage on schema public to intake_writer;
+grant select, insert, update, delete on all tables in schema public to intake_writer;
+grant usage, select on all sequences in schema public to intake_writer;
+grant execute on all functions in schema public to intake_writer;
+
+-- The revocations that matter. Read-only on suppression state: intake must be
+-- able to SEE what is suppressed so it can skip those records, and must not be
+-- able to change it.
+revoke insert, update, delete on public.subject_suppression from intake_writer;
+revoke insert, update, delete on public.suppression_source_key from intake_writer;
+
+-- Intake may file a request that arrived through a source publisher, and may
+-- not dispose of one.
+revoke update, delete on public.correction_request from intake_writer;
+
+-- The audit log is written by trigger under the trigger owner's rights; the
+-- role itself never writes it directly.
+revoke insert, update, delete on public.publication_event from intake_writer;
+revoke insert, update, delete on public.source_retrieval from intake_writer;
+
+comment on role intake_writer is
+'Ingestion role. Full DML on data tables, read-only on suppression state. A pipeline connecting as this role cannot lift a takedown even with a bug or a malicious patch.';
+
+-- ---------------------------------------------------------------------------
+-- 5. Public corrections log
+-- ---------------------------------------------------------------------------
+
+-- What the public can see about our corrections.
+--
+-- The hard call here is naming. A corrections log that says "removed the
+-- record for <person name> on 2026-08-24 following a removal request"
+-- republishes exactly the association the removal was meant to end, and does
+-- it on a page designed to be crawled. So:
+--
+--   * Corrections and suppressions of AGENCIES are named. An agency is not a
+--     data subject and the public interest in knowing we corrected a
+--     department's record is real.
+--   * Anything concerning a PERSON appears without the subject ID or any
+--     identifying detail -- date, action, and coarse reason only.
+--
+-- Requester identity never appears at any granularity.
+create or replace function render.corrections_reason_label(p_reason_code text)
+returns text
+language sql
+immutable
+as $$
+    select case p_reason_code
+        when 'takedown_request' then 'Removal request'
+        when 'legal_hold' then 'Legal hold'
+        when 'data_subject_request' then 'Request from the person named'
+        when 'accuracy_dispute' then 'Accuracy dispute'
+        when 'source_withdrawn' then 'Source withdrew the record'
+        when 'sealed_or_expunged_suspected' then 'Possible sealed or expunged record'
+        when 'personnel_publication_gate' then 'Not yet cleared for publication'
+        else 'Under review'
+    end;
+$$;
+
+create view render.corrections_log as
+select
+    date_trunc('day', pe.occurred_at) as logged_on,
+    pe.subject_type,
+    -- Named for agencies, withheld for people. See the comment above.
+    case when pe.subject_type = 'agency' then pe.subject_id else null end
+        as subject_id,
+    case
+        when pe.to_status = 'blocked' then 'Record withheld'
+        when pe.to_status = 'staged' then 'Record returned to review'
+        when pe.to_status = 'quarantined' then 'Record quarantined pending review'
+        when pe.to_status = 'published' then 'Record published'
+    end as action,
+    render.corrections_reason_label(pe.reason_code) as reason
+from public.publication_event pe
+where pe.reason_code is not null
+    -- Claim-level churn during normal ingestion is not a "correction" in the
+    -- sense the public cares about; only subject-level actions are logged.
+    and pe.claim_id is null
+order by pe.occurred_at desc;
+
+comment on view render.corrections_log is
+'Public corrections log. Agencies are named; anything concerning a person is date/action/reason only, because naming the subject of a removal republishes what the removal withdrew. Requester identity is never exposed.';
+
+alter view render.corrections_log set (security_invoker = off);
+
+-- Explicit grant: `alter default privileges ... revoke all` in the provenance
+-- migration means a new render view is unreadable until someone writes this
+-- line deliberately.
+grant execute on function render.corrections_reason_label(text) to page_renderer;
+grant select on render.corrections_log to page_renderer;
+
+-- assert_provenance_invariant() carries a hard-coded allowlist of render views
+-- the page role may read, and it correctly rejects the grant above until the
+-- allowlist is widened here. That rejection is the feature: adding a public
+-- read surface is a deliberate edit to a named list, reviewed in the diff, not
+-- a side effect of writing a GRANT.
+--
+-- Redefined in full rather than patched, because the allowlist is the only
+-- thing changing and a reader needs to see the other four checks are intact.
+create or replace function public.assert_provenance_invariant()
+returns table (violation text, detail text)
+language sql
+stable
+as $$
+    -- 1. page_renderer must hold no privilege on any table outside `render`.
+    select
+        'renderer_reads_base_table'::text,
+        (table_schema || '.' || table_name || ' [' || privilege_type || ']')::text
+    from information_schema.table_privileges
+    where grantee = 'page_renderer'
+        and table_schema <> 'render'
+
+    union all
+
+    -- 2. page_renderer must hold no privilege on a render object outside the
+    --    reviewed allowlist. Catches a future `grant select on all tables`.
+    --    `corrections_log` added by INS-9: it is a public surface by design and
+    --    exposes no bare value column and no requester identity.
+    select
+        'renderer_grant_outside_allowlist'::text,
+        (table_name || ' [' || privilege_type || ']')::text
+    from information_schema.table_privileges
+    where grantee = 'page_renderer'
+        and table_schema = 'render'
+        and table_name not in
+            ('published_claim', 'published_agency', 'corrections_log')
+
+    union all
+
+    -- 3. The personnel gate must remain closed.
+    select
+        'personnel_gate_open'::text,
+        'page_renderer holds ' || privilege_type || ' on render.published_person'
+    from information_schema.table_privileges
+    where grantee = 'page_renderer'
+        and table_schema = 'render'
+        and table_name = 'published_person'
+
+    union all
+
+    -- 4. No render view may expose a bare value column.
+    select
+        'render_view_exposes_bare_value'::text,
+        (table_name || '.' || column_name)::text
+    from information_schema.columns
+    where table_schema = 'render'
+        and column_name in ('value_text', 'value_number', 'value_date', 'value_boolean');
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 6. Self-check the suppression invariant holds
+-- ---------------------------------------------------------------------------
+
+-- The counterpart to assert_provenance_invariant(). Empty result means intact.
+-- Run in CI after every migration; a non-empty result fails the build. This is
+-- what catches a later migration that re-grants the suppression tables with a
+-- convenient `grant all on all tables in schema public`.
+create or replace function public.assert_suppression_invariant()
+returns table (violation text, detail text)
+language sql
+stable
+as $$
+    -- 1. The ingestion role must not be able to change suppression state.
+    select
+        'intake_can_modify_suppression'::text,
+        (table_name || ' [' || privilege_type || ']')::text
+    from information_schema.table_privileges
+    where grantee = 'intake_writer'
+        and table_schema = 'public'
+        and table_name in ('subject_suppression', 'suppression_source_key')
+        and privilege_type in ('INSERT', 'UPDATE', 'DELETE')
+
+    union all
+
+    -- 2. The ingestion role must not be able to rewrite the audit trail.
+    select
+        'intake_can_modify_audit_trail'::text,
+        (table_name || ' [' || privilege_type || ']')::text
+    from information_schema.table_privileges
+    where grantee = 'intake_writer'
+        and table_schema = 'public'
+        and table_name in ('publication_event', 'source_retrieval')
+        and privilege_type in ('INSERT', 'UPDATE', 'DELETE')
+
+    union all
+
+    -- 3. No actively-suppressed subject may appear in a render view. This is
+    --    the outcome the whole mechanism exists to produce, checked directly
+    --    against the views rather than inferred from the code that builds them.
+    select
+        'suppressed_subject_is_renderable'::text,
+        (sup.subject_type || '/' || sup.subject_id
+            || ' visible via render.published_claim')::text
+    from public.subject_suppression sup
+    where sup.lifted_at is null
+        and exists (
+            select 1 from render.published_claim rc
+            where rc.subject_type = sup.subject_type
+                and rc.subject_id = sup.subject_id
+        )
+
+    union all
+
+    select
+        'suppressed_subject_is_renderable'::text,
+        ('agency/' || sup.subject_id || ' visible via render.published_agency')::text
+    from public.subject_suppression sup
+    where sup.lifted_at is null
+        and exists (
+            select 1 from render.published_agency ra
+            where ra.agency_id = sup.subject_id
+        )
+
+    union all
+
+    -- 4. The renderer must not be able to read requester identity.
+    select
+        'renderer_can_read_requesters'::text,
+        (table_schema || '.' || table_name || ' [' || privilege_type || ']')::text
+    from information_schema.table_privileges
+    where grantee = 'page_renderer'
+        and table_name = 'correction_request'
+
+    union all
+
+    select
+        'corrections_log_exposes_requester'::text,
+        ('render.corrections_log.' || column_name)::text
+    from information_schema.columns
+    where table_schema = 'render'
+        and table_name = 'corrections_log'
+        and column_name in
+            ('requester_name', 'requester_contact', 'requester_role', 'request_text')
+
+    union all
+
+    -- 5. The corrections log must not name a person.
+    select
+        'corrections_log_names_person'::text,
+        ('subject_id disclosed for subject_type=' || cl.subject_type)::text
+    from render.corrections_log cl
+    where cl.subject_type <> 'agency'
+        and cl.subject_id is not null
+
+    union all
+
+    -- 6. A legal demand must not have been resolved without escalation.
+    select
+        'legal_demand_resolved_without_escalation'::text,
+        cr.request_id::text
+    from public.correction_request cr
+    where cr.request_kind in ('legal_demand', 'sealed_or_expunged')
+        and cr.disposition in ('action_taken', 'declined')
+        and cr.escalated_at is null;
+$$;
+
+comment on function public.assert_suppression_invariant() is
+'Returns zero rows when the corrections/takedown invariant is intact. Non-empty means a suppressed record is reachable, the ingestion role can undo a takedown, requester identity is exposed, or a legal demand was resolved without escalation.';
+
+commit;

--- a/test/schema/corrections-takedown.test.ts
+++ b/test/schema/corrections-takedown.test.ts
@@ -1,0 +1,689 @@
+/**
+ * Demonstrated enforcement of the corrections and takedown mechanism (INS-9).
+ *
+ * The issue's done-when clause is: a record can be suppressed, survives a full
+ * pipeline re-run still suppressed, and the action is logged. The three
+ * describe blocks below are those three clauses, plus the intake path and the
+ * public log.
+ *
+ * The re-run test is the one that matters. It replays the two ways a takedown
+ * honoured on Tuesday gets undone on Wednesday:
+ *
+ *   a) the loader re-imports the same upstream row and overwrites the record;
+ *   b) the source-name-to-canonical-ID ledger is regenerated, the loader
+ *      assigns a NEW canonical ID to the SAME upstream row, and every
+ *      suppression check keyed on the old ID passes.
+ *
+ * (b) is the one that would actually happen, because that ledger is a YAML
+ * file on disk outside the database.
+ *
+ * Requires a Postgres connection string in TEST_DATABASE_URL. The suite skips
+ * itself when that is absent so `npm test` stays green without a database.
+ * TEST_DATABASE_URL must be a fully-qualified URL with a host, because the
+ * ingestion-role tests rewrite its credentials.
+ *
+ *   createdb intake_schema_test
+ *   TEST_DATABASE_URL=postgres://localhost:5432/intake_schema_test \
+ *     npm run test:vitest -- test/schema
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { Client } from "pg";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+const DATABASE_URL = process.env.TEST_DATABASE_URL;
+
+const PROVENANCE_MIGRATION = fileURLToPath(
+  new URL(
+    "../../supabase/migrations/20260824170000_provenance_structural_invariant.sql",
+    import.meta.url,
+  ),
+);
+const CORRECTIONS_MIGRATION = fileURLToPath(
+  new URL(
+    "../../supabase/migrations/20260824190000_corrections_and_takedown.sql",
+    import.meta.url,
+  ),
+);
+const FIXTURE_PATH = fileURLToPath(
+  new URL("./upstream-fixture.sql", import.meta.url),
+);
+
+const SOURCE = "src_ins9_0001";
+const RETRIEVAL = "ret_ins9_0001";
+/** A second pull of the same source: what a re-run produces. */
+const RETRIEVAL_RERUN = "ret_ins9_0002";
+
+const AGENCY = "agency_ins9_subject";
+/** The upstream record key the source uses for that agency. Stable across runs. */
+const SOURCE_RECORD_KEY = "TX0570000";
+/** The canonical ID a regenerated mapping ledger would assign on a re-run. */
+const AGENCY_REIDENTIFIED = "agency_ins9_reidentified";
+
+const SUPPRESSION = "sup_ins9_0001";
+
+let admin: Client;
+/** Connected as `intake_writer`: what the loader is supposed to connect as. */
+let loader: Client;
+
+/** Run SQL and return the error message, or throw if it unexpectedly succeeded. */
+async function rejects(
+  client: Client,
+  sql: string,
+  params: unknown[] = [],
+): Promise<string> {
+  try {
+    await client.query(sql, params);
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error(`expected statement to be rejected but it succeeded: ${sql}`);
+}
+
+/** Insert a claim about the agency, as the given subject/source-key pair. */
+async function insertClaim(
+  client: Client,
+  options: {
+    claimId: string;
+    subjectId?: string;
+    retrievalId?: string;
+    sourceRecordKey?: string;
+    status?: string;
+    value?: string;
+  },
+): Promise<void> {
+  await client.query(
+    `insert into public.claim
+       (claim_id, subject_type, subject_id, predicate, value_text,
+        retrieval_id, source_record_key, confidence, confidence_basis,
+        publication_status)
+     values ($1, 'agency', $2, 'agency_name', $3, $4, $5, 1.0,
+             'source_asserted', $6)`,
+    [
+      options.claimId,
+      options.subjectId ?? AGENCY,
+      options.value ?? "Example Police Department",
+      options.retrievalId ?? RETRIEVAL,
+      options.sourceRecordKey ?? SOURCE_RECORD_KEY,
+      options.status ?? "published",
+    ],
+  );
+}
+
+/** Apply a suppression the way the corrections process would. */
+async function suppress(
+  suppressionId: string,
+  subjectId: string,
+  reasonCode = "takedown_request",
+): Promise<void> {
+  await admin.query(`select set_config('intake.actor', $1, false)`, [
+    "founding-engineer",
+  ]);
+  await admin.query(
+    `insert into public.subject_suppression
+       (suppression_id, subject_type, subject_id, reason_code, reason_note,
+        requested_by, applied_by)
+     values ($1, 'agency', $2, $3, 'Applied pending Executive Director review.',
+             'requester-of-record', 'founding-engineer')`,
+    [suppressionId, subjectId, reasonCode],
+  );
+}
+
+describe.skipIf(!DATABASE_URL)("corrections and takedown mechanics", () => {
+  beforeAll(async () => {
+    admin = new Client({ connectionString: DATABASE_URL });
+    await admin.connect();
+
+    // Start from a known-empty state so the suite is re-runnable.
+    await admin.query(`drop schema if exists render cascade`);
+    await admin.query(`drop schema if exists public cascade`);
+    await admin.query(`create schema public`);
+    for (const role of ["page_renderer", "intake_writer"]) {
+      await admin.query(`drop owned by ${role}`).catch(() => {});
+      await admin.query(`drop role if exists ${role}`).catch(() => {});
+    }
+
+    const agencyExists = await admin.query(
+      `select to_regclass('public.agency') is not null as present`,
+    );
+    if (!agencyExists.rows[0].present) {
+      await admin.query(readFileSync(FIXTURE_PATH, "utf8"));
+    }
+
+    await admin.query(readFileSync(PROVENANCE_MIGRATION, "utf8"));
+    await admin.query(readFileSync(CORRECTIONS_MIGRATION, "utf8"));
+
+    await admin.query(
+      `insert into public.source
+         (source_id, slug, name, publisher, access_basis, terms_status,
+          terms_reviewed_at, terms_reviewed_by)
+       values ($1, 'ins9-test-source', 'INS-9 Test Source', 'Test Publisher',
+               'public_api', 'cleared', now(), 'founding-engineer')`,
+      [SOURCE],
+    );
+
+    // Two retrievals of the same source: the first run and the re-run.
+    for (const [id, when] of [
+      [RETRIEVAL, "2026-08-20T00:00:00Z"],
+      [RETRIEVAL_RERUN, "2026-08-24T00:00:00Z"],
+    ]) {
+      await admin.query(
+        `insert into public.source_retrieval
+           (retrieval_id, source_id, retrieved_at, source_url, content_hash)
+         values ($1, $2, $3, 'https://example.gov/roster', 'hash-' || $1)`,
+        [id, SOURCE, when],
+      );
+    }
+
+    await admin.query(
+      `insert into public.claim_predicate
+         (predicate, subject_type, datatype, description)
+       values ('agency_name', 'agency', 'text', 'Agency name as published by the source')`,
+    );
+
+    // Log in as the ingestion role to prove the privilege boundary, not just
+    // the triggers. Rewrite the URL's credentials, keeping host and database.
+    const loaderUrl = new URL(DATABASE_URL!);
+    loaderUrl.username = "intake_writer";
+    loaderUrl.password = "";
+    await admin.query(`alter role intake_writer login`);
+    loader = new Client({ connectionString: loaderUrl.toString() });
+    await loader.connect();
+  }, 60_000);
+
+  afterAll(async () => {
+    await loader?.end();
+    await admin?.end();
+  });
+
+  /**
+   * Every table this suite touches is append-only, undeletable, or guarded --
+   * that is the whole point of the migration -- so resetting between tests
+   * means turning the guards off, truncating, and turning them back on.
+   *
+   * `alter table ... disable trigger` requires table ownership, which no live
+   * role holds: intake_writer and page_renderer both fail this statement. The
+   * escape hatch exists for the test harness and is unreachable in production.
+   */
+  const GUARDS: ReadonlyArray<[table: string, trigger: string]> = [
+    ["public.subject_suppression", "subject_suppression_no_delete"],
+    ["public.claim", "claim_suppression_guard"],
+    ["public.publication_event", "publication_event_append_only"],
+    ["public.correction_request", "correction_request_no_delete"],
+    ["public.agency", "agency_suppression_guard"],
+  ];
+
+  beforeEach(async () => {
+    for (const [table, trigger] of GUARDS) {
+      await admin.query(`alter table ${table} disable trigger ${trigger}`);
+    }
+
+    // publication_event first: its claim_id FK is `on delete set null`, so
+    // deleting a claim UPDATEs the audit row, which the append-only trigger
+    // rejects. An audited claim is effectively undeletable in production, and
+    // that is the correct behaviour -- here it just means ordering matters.
+    await admin.query(`delete from public.publication_event`);
+    await admin.query(`delete from public.claim`);
+    await admin.query(`delete from public.suppression_source_key`);
+    await admin.query(`delete from public.subject_suppression`);
+    await admin.query(`delete from public.correction_request`);
+
+    for (const id of [AGENCY, AGENCY_REIDENTIFIED]) {
+      await admin.query(`delete from public.agency where id = $1`, [id]);
+      await admin.query(
+        `insert into public.agency (id, name, state)
+         values ($1, 'Example Police Department', 'TX')`,
+        [id],
+      );
+    }
+
+    for (const [table, trigger] of GUARDS) {
+      await admin.query(`alter table ${table} enable trigger ${trigger}`);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+
+  describe("a record can be suppressed", () => {
+    it("removes the subject from the public render surface", async () => {
+      await insertClaim(admin, { claimId: "clm_ins9_visible" });
+
+      const before = await admin.query(
+        `select 1 from render.published_claim where subject_id = $1`,
+        [AGENCY],
+      );
+      expect(before.rowCount).toBe(1);
+
+      await suppress(SUPPRESSION, AGENCY);
+
+      const after = await admin.query(
+        `select 1 from render.published_claim where subject_id = $1`,
+        [AGENCY],
+      );
+      expect(after.rowCount).toBe(0);
+    });
+
+    it("captures the upstream record keys behind the subject", async () => {
+      await insertClaim(admin, { claimId: "clm_ins9_keyed" });
+      await suppress(SUPPRESSION, AGENCY);
+
+      const keys = await admin.query(
+        `select source_id, source_record_key
+         from public.suppression_source_key where suppression_id = $1`,
+        [SUPPRESSION],
+      );
+      expect(keys.rows).toEqual([
+        { source_id: SOURCE, source_record_key: SOURCE_RECORD_KEY },
+      ]);
+    });
+
+    it("reports no violations from the invariant self-check", async () => {
+      await insertClaim(admin, { claimId: "clm_ins9_check" });
+      await suppress(SUPPRESSION, AGENCY);
+
+      const violations = await admin.query(
+        `select * from public.assert_suppression_invariant()`,
+      );
+      expect(violations.rows).toEqual([]);
+
+      const provenance = await admin.query(
+        `select * from public.assert_provenance_invariant()`,
+      );
+      expect(provenance.rows).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+
+  describe("suppression survives a full pipeline re-run", () => {
+    beforeEach(async () => {
+      await insertClaim(admin, { claimId: "clm_ins9_original" });
+      await suppress(SUPPRESSION, AGENCY);
+    });
+
+    it("refuses a re-import of the same subject under the same canonical ID", async () => {
+      const message = await rejects(
+        loader,
+        `insert into public.claim
+           (claim_id, subject_type, subject_id, predicate, value_text,
+            retrieval_id, source_record_key, confidence, confidence_basis,
+            publication_status)
+         values ('clm_ins9_rerun', 'agency', $1, 'agency_name',
+                 'Example Police Department', $2, $3, 1.0,
+                 'source_asserted', 'published')`,
+        [AGENCY, RETRIEVAL_RERUN, SOURCE_RECORD_KEY],
+      );
+
+      expect(message).toContain("under active suppression");
+      expect(message).toContain(SUPPRESSION);
+    });
+
+    it("refuses a re-import of the same upstream row under a NEW canonical ID", async () => {
+      // The regenerated-ledger case. Every check keyed on the canonical ID
+      // passes here -- AGENCY_REIDENTIFIED has no suppression row of its own.
+      // Only the source-record-key guard catches this.
+      expect(
+        await admin.query(`select public.is_id_suppressed($1) as sup`, [
+          AGENCY_REIDENTIFIED,
+        ]),
+      ).toMatchObject({ rows: [{ sup: null }] });
+
+      const message = await rejects(
+        loader,
+        `insert into public.claim
+           (claim_id, subject_type, subject_id, predicate, value_text,
+            retrieval_id, source_record_key, confidence, confidence_basis,
+            publication_status)
+         values ('clm_ins9_reidentified', 'agency', $1, 'agency_name',
+                 'Example Police Department', $2, $3, 1.0,
+                 'source_asserted', 'published')`,
+        [AGENCY_REIDENTIFIED, RETRIEVAL_RERUN, SOURCE_RECORD_KEY],
+      );
+
+      expect(message).toContain("under active suppression");
+      expect(message).toContain(SUPPRESSION);
+    });
+
+    it("refuses an in-place update of the suppressed entity row", async () => {
+      // The loader classifies an existing agency with owned columns as an
+      // `update` and writes public.agency directly. Under a legal hold that
+      // would overwrite the record we are holding.
+      const message = await rejects(
+        loader,
+        `update public.agency set name = 'Renamed By Reimport' where id = $1`,
+        [AGENCY],
+      );
+      expect(message).toContain("under active suppression");
+    });
+
+    it("refuses a delete-and-recreate of the suppressed entity row", async () => {
+      const message = await rejects(
+        loader,
+        `delete from public.agency where id = $1`,
+        [AGENCY],
+      );
+      expect(message).toContain("under active suppression");
+    });
+
+    it("denies the ingestion role any privilege to lift a suppression", async () => {
+      // Belt and braces: the triggers above stop an accidental lift, this
+      // stops a deliberate one and survives a future migration that drops a
+      // trigger.
+      const update = await rejects(
+        loader,
+        `update public.subject_suppression set lifted_at = now(),
+           lifted_by = 'loader', lift_note = 'reimport' where suppression_id = $1`,
+        [SUPPRESSION],
+      );
+      expect(update).toMatch(/permission denied/i);
+
+      const remove = await rejects(
+        loader,
+        `delete from public.subject_suppression where suppression_id = $1`,
+        [SUPPRESSION],
+      );
+      expect(remove).toMatch(/permission denied/i);
+
+      const insert = await rejects(
+        loader,
+        `insert into public.suppression_source_key
+           (suppression_id, source_id, source_record_key)
+         values ($1, $2, 'forged')`,
+        [SUPPRESSION, SOURCE],
+      );
+      expect(insert).toMatch(/permission denied/i);
+    });
+
+    it("lets the ingestion role READ suppression state so it can skip records", async () => {
+      // Read access is required, not incidental: intake pre-filters suppressed
+      // subjects so the guard above stays a backstop rather than the routine
+      // failure path.
+      const visible = await loader.query(
+        `select public.is_source_key_suppressed($1, $2) as sup`,
+        [SOURCE, SOURCE_RECORD_KEY],
+      );
+      expect(visible.rows[0].sup).toBe(SUPPRESSION);
+    });
+
+    it("keeps the subject off the render surface after the re-run attempt", async () => {
+      await rejects(
+        loader,
+        `update public.agency set name = 'Renamed By Reimport' where id = $1`,
+        [AGENCY],
+      );
+
+      const rendered = await admin.query(
+        `select 1 from render.published_claim where subject_id = $1`,
+        [AGENCY],
+      );
+      expect(rendered.rowCount).toBe(0);
+
+      const violations = await admin.query(
+        `select * from public.assert_suppression_invariant()`,
+      );
+      expect(violations.rows).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+
+  describe("the action is logged", () => {
+    it("writes an audit event naming the actor, reason, and basis", async () => {
+      await insertClaim(admin, { claimId: "clm_ins9_logged" });
+      await suppress(SUPPRESSION, AGENCY);
+
+      const events = await admin.query(
+        `select subject_type, subject_id, to_status, reason_code, reason_note, actor
+         from public.publication_event
+         where subject_id = $1 and claim_id is null`,
+        [AGENCY],
+      );
+
+      expect(events.rows).toEqual([
+        {
+          subject_type: "agency",
+          subject_id: AGENCY,
+          to_status: "blocked",
+          reason_code: "takedown_request",
+          reason_note: "Applied pending Executive Director review.",
+          actor: "founding-engineer",
+        },
+      ]);
+    });
+
+    it("refuses to delete a suppression, so the evidence cannot be erased", async () => {
+      await suppress(SUPPRESSION, AGENCY);
+      const message = await rejects(
+        admin,
+        `delete from public.subject_suppression where suppression_id = $1`,
+        [SUPPRESSION],
+      );
+      expect(message).toContain("not deletable");
+    });
+
+    it("refuses to rewrite why or against whom a suppression was filed", async () => {
+      await suppress(SUPPRESSION, AGENCY);
+      const message = await rejects(
+        admin,
+        `update public.subject_suppression set reason_code = 'accuracy_dispute'
+         where suppression_id = $1`,
+        [SUPPRESSION],
+      );
+      expect(message).toContain("only the lift fields may be updated");
+    });
+
+    it("refuses to lift a suppression without stating the basis", async () => {
+      await suppress(SUPPRESSION, AGENCY);
+      const message = await rejects(
+        admin,
+        `update public.subject_suppression
+         set lifted_at = now(), lifted_by = 'executive-director'
+         where suppression_id = $1`,
+        [SUPPRESSION],
+      );
+      expect(message).toContain("requires lift_note");
+    });
+
+    it("returns claims to staged on lift rather than republishing them", async () => {
+      await insertClaim(admin, { claimId: "clm_ins9_lift" });
+      await suppress(SUPPRESSION, AGENCY);
+
+      await admin.query(`select set_config('intake.actor', $1, false)`, [
+        "executive-director",
+      ]);
+      await admin.query(
+        `update public.subject_suppression
+         set lifted_at = now(), lifted_by = 'executive-director',
+             lift_note = 'Dispute resolved; wrong subject suppressed.'
+         where suppression_id = $1`,
+        [SUPPRESSION],
+      );
+
+      const claim = await admin.query(
+        `select publication_status from public.claim where claim_id = 'clm_ins9_lift'`,
+      );
+      expect(claim.rows[0].publication_status).toBe("staged");
+
+      // Lifting must not put the page back up by itself.
+      const rendered = await admin.query(
+        `select 1 from render.published_claim where subject_id = $1`,
+        [AGENCY],
+      );
+      expect(rendered.rowCount).toBe(0);
+
+      const lift = await admin.query(
+        `select to_status, actor, reason_note from public.publication_event
+         where subject_id = $1 and claim_id is null and to_status = 'staged'`,
+        [AGENCY],
+      );
+      expect(lift.rows[0]).toMatchObject({
+        to_status: "staged",
+        actor: "executive-director",
+        reason_note: "Dispute resolved; wrong subject suppressed.",
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+
+  describe("intake path", () => {
+    async function fileRequest(requestId: string, kind: string): Promise<void> {
+      await admin.query(
+        `insert into public.correction_request
+           (request_id, channel, request_kind, request_text,
+            requester_name, requester_contact, subject_hint)
+         values ($1, 'email', $2, 'The record about me is wrong.',
+                 'A Requester', 'requester@example.com',
+                 'https://policeconduct.org/agency/example')`,
+        [requestId, kind],
+      );
+    }
+
+    it("accepts a correction request and holds the requester's own words", async () => {
+      await fileRequest("req_ins9_correction", "correction");
+      const row = await admin.query(
+        `select request_text, disposition from public.correction_request
+         where request_id = 'req_ins9_correction'`,
+      );
+      expect(row.rows[0]).toEqual({
+        request_text: "The record about me is wrong.",
+        disposition: "received",
+      });
+    });
+
+    it("refuses to edit the substance of a request after intake", async () => {
+      await fileRequest("req_ins9_immutable", "correction");
+      const message = await rejects(
+        admin,
+        `update public.correction_request set request_text = 'paraphrased'
+         where request_id = 'req_ins9_immutable'`,
+      );
+      expect(message).toContain("immutable after intake");
+    });
+
+    it("refuses to resolve a legal demand that was not escalated", async () => {
+      await fileRequest("req_ins9_legal", "legal_demand");
+      const message = await rejects(
+        admin,
+        `update public.correction_request
+         set disposition = 'action_taken', decided_at = now(), decided_by = 'founding-engineer'
+         where request_id = 'req_ins9_legal'`,
+      );
+      expect(message).toContain("Executive Director");
+    });
+
+    it("allows a legal demand to be escalated, which is where it stops", async () => {
+      await fileRequest("req_ins9_legal_ok", "legal_demand");
+      await admin.query(
+        `update public.correction_request
+         set disposition = 'escalated', escalated_at = now(),
+             escalated_to = 'executive-director'
+         where request_id = 'req_ins9_legal_ok'`,
+      );
+      const row = await admin.query(
+        `select disposition from public.correction_request
+         where request_id = 'req_ins9_legal_ok'`,
+      );
+      expect(row.rows[0].disposition).toBe("escalated");
+    });
+
+    it("refuses to decline a suspected sealed or expunged record", async () => {
+      await fileRequest("req_ins9_sealed", "sealed_or_expunged");
+      const message = await rejects(
+        admin,
+        `update public.correction_request
+         set disposition = 'declined', escalated_at = now(),
+             escalated_to = 'executive-director',
+             decided_at = now(), decided_by = 'executive-director'
+         where request_id = 'req_ins9_sealed'`,
+      );
+      expect(message).toContain("cannot be declined");
+    });
+
+    it("refuses to close a request without naming who decided", async () => {
+      await fileRequest("req_ins9_unattributed", "correction");
+      const message = await rejects(
+        admin,
+        `update public.correction_request set disposition = 'declined'
+         where request_id = 'req_ins9_unattributed'`,
+      );
+      expect(message).toMatch(/correction_request_resolution_attributed/);
+    });
+
+    it("refuses to delete a request", async () => {
+      await fileRequest("req_ins9_undeletable", "correction");
+      const message = await rejects(
+        admin,
+        `delete from public.correction_request where request_id = 'req_ins9_undeletable'`,
+      );
+      expect(message).toContain("not deletable");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+
+  describe("public corrections log", () => {
+    it("names the agency when an agency record is withheld", async () => {
+      await insertClaim(admin, { claimId: "clm_ins9_log_agency" });
+      await suppress(SUPPRESSION, AGENCY, "accuracy_dispute");
+
+      const log = await admin.query(
+        `select subject_type, subject_id, action, reason
+         from render.corrections_log`,
+      );
+      expect(log.rows).toEqual([
+        {
+          subject_type: "agency",
+          subject_id: AGENCY,
+          action: "Record withheld",
+          reason: "Accuracy dispute",
+        },
+      ]);
+    });
+
+    it("withholds the subject ID when the record concerns a person", async () => {
+      // Naming the person whose record was removed republishes the association
+      // the removal was meant to end -- on a page built to be crawled.
+      await admin.query(`select set_config('intake.actor', 'ed', false)`);
+      await admin.query(
+        `insert into public.subject_suppression
+           (suppression_id, subject_type, subject_id, reason_code, applied_by)
+         values ('sup_ins9_person', 'person', 'person_ins9_0001',
+                 'data_subject_request', 'executive-director')`,
+      );
+
+      const log = await admin.query(
+        `select subject_type, subject_id, action, reason
+         from render.corrections_log`,
+      );
+      expect(log.rows).toEqual([
+        {
+          subject_type: "person",
+          subject_id: null,
+          action: "Record withheld",
+          reason: "Request from the person named",
+        },
+      ]);
+    });
+
+    it("exposes no requester identity to the page role", async () => {
+      const columns = await admin.query(
+        `select column_name from information_schema.columns
+         where table_schema = 'render' and table_name = 'corrections_log'`,
+      );
+      const names = columns.rows.map((row) => row.column_name);
+      expect(names).not.toContain("requester_name");
+      expect(names).not.toContain("requester_contact");
+      expect(names).not.toContain("request_text");
+    });
+
+    it("does not grant the page role access to the request table", async () => {
+      const granted = await admin.query(
+        `select 1 from information_schema.table_privileges
+         where grantee = 'page_renderer' and table_name = 'correction_request'`,
+      );
+      expect(granted.rowCount).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Closes INS-9. **Stacked on #60** — based on `feat/provenance-structural-invariant`, merge that first.

## The problem

#60 gave us suppression *state*: an active `subject_suppression` row removes a subject from every render view, and `publication_event` is an append-only status log. What it did not give us is a takedown that survives contact with the ingestion pipeline.

Two ways a takedown honoured on Tuesday is undone on Wednesday:

**A — the pipeline overwrites the record.** The loader classifies an existing agency with owned columns as an `update` and writes `public.agency` directly. Under a legal hold that overwrites the record we are holding.

**B — the pipeline reintroduces the record under a new ID.** Intake maps source record keys to canonical cuid2 IDs through a YAML ledger on disk (`src/cli/state/source-name-to-canonical-id`). `subject_suppression` is keyed on the canonical ID. If that ledger is regenerated, lost, or diverges, a re-import assigns a **new** canonical ID to the **same** upstream row. The suppression row survives, still pointing at the old ID, and protects nothing. Every canonical-ID check passes.

B is the dangerous one: it is silent, the ledger lives outside the database where the suppression lives, and nothing about it looks like a failure. The import succeeds and the row count goes up by one.

Suppression keyed only on our own identifier cannot survive a change to our own identifier.

## What this does

**Anchors suppression to the source's record key.** `suppression_source_key` captures the upstream `(source_id, source_record_key)` pairs behind a subject — by trigger, at the moment of suppression, because whoever honours a takedown at 11pm will not remember to enumerate them by hand. The claim guard refuses a write matching *either* the canonical ID or the upstream key.

**Intake path.** `correction_request` records channel, kind, and the requester's verbatim words. Substance is immutable after intake, the row is undeletable, and a resolved request must name who decided.

**The INS-9 boundary as a constraint, not a runbook paragraph.** A `legal_demand` or `sealed_or_expunged` request cannot be marked `action_taken` or `declined` unless it was escalated first, and a suspected sealed record cannot be declined at all.

**Audit that cannot be erased.** `subject_suppression` DELETE is refused outright; UPDATE is restricted to the lift fields, once, with a required basis. Apply and lift both write `publication_event`.

**Lifting does not republish.** A lift returns claims to `staged`, never to `published`. A suppression is lifted for several reasons and none of them is the same decision as "this is fit to publish" — an accidental lift must not re-expose a page.

**Two independent defences.** The triggers stop an accidental un-suppression. `intake_writer` — DML on data tables, SELECT-only on suppression state and the audit log — stops a deliberate one, and survives a future migration that drops a trigger. Neither depends on the other.

**Public corrections log.** `render.corrections_log`, granted explicitly to `page_renderer`.

## The one judgement call worth reviewing

The corrections log names **agencies** but not **people**.

A log entry reading *"removed the record for [name] following a removal request"* republishes exactly the association the removal was meant to end, on a page built to be crawled. It would become a directory of people who asked to be taken down. So agencies — not data subjects, real public interest — are named; anything concerning a person is date, action, and coarse reason only. Requester identity never appears at any granularity.

The cost: the log is less informative for the personnel corpus, which is the larger half. I think that is the right trade, but it is a product decision as much as an engineering one.

## Verification

- 26 new tests in `test/schema/corrections-takedown.test.ts`, one per clause of the issue's done-when. **68/68 schema tests pass** from a clean database on PostgreSQL 18.4.
- The re-import tests run as `intake_writer` against a real connection, so they exercise the privilege boundary and not just the triggers.
- `assert_suppression_invariant()` verified **not vacuous**: granting the ingestion role UPDATE on `subject_suppression` makes `npm run assert:suppression` exit 1 with `intake_can_modify_suppression`.
- `npx tsc --noEmit` clean; `openspec validate --all` passes.
- `test:schema` added with `--no-file-parallelism`: both schema suites reset the `public` schema, so running them concurrently against one database is a race.

Not yet verified against a real `supabase db reset` database rather than the fixture — same gap as #60, tracked with INS-30.

## Follow-ups filed, not done here

- **Source-key plumbing for the legacy tables.** `public.agency` and `public.officers` carry no `source_record_key`, so failure mode B cannot be blocked in the database for the corpus behind the 132,109 live personnel pages. Guarded against A (UPDATE/DELETE) only. Needs source record keys threaded through `ImportRows`.
- Surface suppressed-record skips in the load's change diff.
- Public `/corrections/` page on policeconduct.org — blocked until this migration is applied to the real database.

## Deployment note

Loaders must be repointed to connect as `intake_writer`. A loader still connecting as the database owner is outside the privilege guarantee, which is why the invariant check inspects grants rather than trusting the connection string.