### PR TITLE
Report suppressed-record skips in the ingestion change diff

### DIFF
--- a/openspec/changes/2026-08-24-corrections-and-takedown/specs/corrections-and-takedown/spec.md
+++ b/openspec/changes/2026-08-24-corrections-and-takedown/specs/corrections-and-takedown/spec.md
@@ -129,6 +129,38 @@ removed.
 - **WHEN** a later migration grants the ingestion role UPDATE on `subject_suppression`
 - **THEN** `assert_suppression_invariant()` returns `intake_can_modify_suppression`
 
+### Requirement: An Import Reports The Records It Skipped As Suppressed
+
+An import run MUST report the count and the identity of every record it
+declined to write because a subject is under an active suppression. A skipped
+record MUST be distinguishable from a record that simply had nothing to update:
+both are planned as `read`, and a change diff that cannot tell them apart
+cannot explain what the load did.
+
+A record the import owns no columns on MUST NOT be reported as a suppressed
+skip. Nothing was going to be written for it, and counting it would overstate
+what the suppression cost.
+
+#### Scenario: A suppressed record is named in the run output
+
+- **WHEN** an import would have updated a record whose subject is suppressed
+- **THEN** the run reports the count of skipped records, and for each one its entity type, canonical ID, the suppressed subject IDs that caused the skip, and the columns it withheld
+
+#### Scenario: A link is skipped for the subject it points at
+
+- **WHEN** an agency-personnel link is skipped because the person it points at is suppressed, not the link itself
+- **THEN** the report names the suppressed person as the cause, not the link
+
+#### Scenario: A record with nothing to write is not a skip
+
+- **WHEN** a suppressed record exists but this import owns no columns on it
+- **THEN** the run reports no suppressed skip for it
+
+#### Scenario: The skip survives the run
+
+- **WHEN** an import writes its DatabaseMutations envelope after skipping a suppressed record
+- **THEN** the envelope metadata carries the skip, so the next run's diff can see it
+
 ### Requirement: Suppression Actions Are Logged And Cannot Be Erased
 
 Applying and lifting a suppression MUST write an append-only audit event naming

--- a/openspec/changes/2026-08-24-corrections-and-takedown/tasks.md
+++ b/openspec/changes/2026-08-24-corrections-and-takedown/tasks.md
@@ -79,7 +79,14 @@
       blocked in the database for the legacy corpus that renders the 132,109
       live personnel pages. Needs source record keys threaded through
       `ImportRows`.
-- [ ] Surface suppressed-record skips in the load's change diff.
+- [x] Surface suppressed-record skips in the load's change diff. Done in
+      INS-37: `DatabaseRowOperations.suppressedSkips` carries entity, canonical
+      ID, the suppressed subject IDs that caused the skip, and the withheld
+      columns; the CLI prints count and identity, the run log carries the
+      structured form, and the DatabaseMutations envelope metadata persists it.
+      Not covered there: a suppressed subject whose row does not exist is still
+      planned as `create`, because `enforce_entity_not_suppressed` fires on
+      UPDATE and DELETE only. Filed separately.
 - [ ] Public `/corrections/` page on policeconduct.org, reading
       `render.corrections_log`. Blocked until this migration is applied to the
       real database; a page querying a view that does not exist yet would fail

--- a/src/cli/import/artifacts/classify-database-operations.ts
+++ b/src/cli/import/artifacts/classify-database-operations.ts
@@ -6,7 +6,11 @@ import {
 import { readLocationPathAliasByPath } from "../../database/location-paths.js";
 import type { SupportedTableName } from "../../database/schema.js";
 import { readActiveSuppressedIds } from "../../database/suppression.js";
-import type { DatabaseRowOperations } from "./operations.js";
+import type {
+  DatabaseRowOperations,
+  SuppressedSkip,
+  SuppressedSkipEntity,
+} from "./operations.js";
 import type { ImportRows, LocationPathRow } from "./transform.js";
 
 async function rowExists(
@@ -15,6 +19,45 @@ async function rowExists(
   rowId: string,
 ): Promise<boolean> {
   return (await readDatabaseRecordById(client, tableName, rowId)) !== undefined;
+}
+
+/**
+ * Classify an existing row, recording the skip when suppression is what
+ * demoted it.
+ *
+ * The order of the checks is the point. A record with no owned columns is not
+ * a skip -- this import had nothing to write for it, suppressed or not, and
+ * reporting it as a skipped takedown would inflate the number that matters.
+ * Only a write we were actually going to make and then withheld counts.
+ */
+function classifyExistingRow(
+  skips: Map<string, SuppressedSkip>,
+  suppressedIds: ReadonlySet<string>,
+  entity: SuppressedSkipEntity,
+  recordId: string,
+  ownedColumns: readonly string[],
+  subjectIds: readonly string[],
+): "read" | "update" {
+  if (ownedColumns.length === 0) {
+    return "read";
+  }
+  const suppressedSubjectIds = [...new Set(subjectIds)].filter((subjectId) =>
+    suppressedIds.has(subjectId),
+  );
+  if (suppressedSubjectIds.length === 0) {
+    return "update";
+  }
+  // Keyed rather than appended: rows.officers is classified without the
+  // already-seen guard the agency loop has, so the same record can be visited
+  // twice. A change diff that double-counts an honoured takedown is its own
+  // small lie.
+  skips.set(`${entity}:${recordId}`, {
+    entity,
+    recordId,
+    suppressedSubjectIds,
+    withheldColumns: [...ownedColumns],
+  });
+  return "read";
 }
 
 export async function classifyDatabaseOperations(
@@ -35,7 +78,13 @@ export async function classifyDatabaseOperations(
     agencies: {},
     officers: {},
     agencyOfficers: {},
+    suppressedSkips: [],
   };
+  // Owned by classification, and rebuilt on every call. `preparedOperations`
+  // reaches us through a cast from ImportOperations, which has no such field,
+  // so it can arrive undefined; and a re-run must not accumulate skips from
+  // the previous pass.
+  const suppressedSkips = new Map<string, SuppressedSkip>();
   const databaseLocationPathIds = new Set(
     databaseLocationPaths.map((locationPath) => locationPath.location_path_id),
   );
@@ -110,20 +159,28 @@ export async function classifyDatabaseOperations(
     }
     const exists = await rowExists(client, "public.agency", agency.id);
     operations.agencies[agency.id] = exists
-      ? (rows.ownedColumns.agencies[agency.id] ?? []).length > 0 &&
-        !suppressedIds.has(agency.id)
-        ? "update"
-        : "read"
+      ? classifyExistingRow(
+          suppressedSkips,
+          suppressedIds,
+          "agency",
+          agency.id,
+          rows.ownedColumns.agencies[agency.id] ?? [],
+          [agency.id],
+        )
       : "create";
   }
 
   for (const officer of rows.officers) {
     const exists = await rowExists(client, "public.officers", officer.id);
     operations.officers[officer.id] = exists
-      ? (rows.ownedColumns.officers[officer.id] ?? []).length > 0 &&
-        !suppressedIds.has(officer.id)
-        ? "update"
-        : "read"
+      ? classifyExistingRow(
+          suppressedSkips,
+          suppressedIds,
+          "personnel",
+          officer.id,
+          rows.ownedColumns.officers[officer.id] ?? [],
+          [officer.id],
+        )
       : "create";
   }
 
@@ -134,14 +191,22 @@ export async function classifyDatabaseOperations(
       agencyOfficer.id,
     );
     operations.agencyOfficers[agencyOfficer.id] = exists
-      ? (rows.ownedColumns.agencyOfficers[agencyOfficer.id] ?? []).length > 0 &&
-        !suppressedIds.has(agencyOfficer.id) &&
-        !suppressedIds.has(agencyOfficer.personnel_id) &&
-        !suppressedIds.has(agencyOfficer.agency_id)
-        ? "update"
-        : "read"
+      ? classifyExistingRow(
+          suppressedSkips,
+          suppressedIds,
+          "agencyPersonnel",
+          agencyOfficer.id,
+          rows.ownedColumns.agencyOfficers[agencyOfficer.id] ?? [],
+          [
+            agencyOfficer.id,
+            agencyOfficer.personnel_id,
+            agencyOfficer.agency_id,
+          ],
+        )
       : "create";
   }
+
+  operations.suppressedSkips = [...suppressedSkips.values()];
 
   return operations;
 }

--- a/src/cli/import/artifacts/config.ts
+++ b/src/cli/import/artifacts/config.ts
@@ -61,6 +61,8 @@ import {
   writeResolvedProperty,
 } from "../../state/resolved-property/index.js";
 import { replayDatabaseMutations } from "../../replay/database-mutations/config.js";
+import type { SuppressedSkip } from "./operations.js";
+import { suppressedSkipLogFields } from "./suppressed-skips.js";
 import type { ImportRows, ResolvedProperties } from "./transform.js";
 import { transformArtifacts } from "./transform.js";
 import {
@@ -78,7 +80,16 @@ type ImportLogger = {
 };
 
 export type ImportArtifactsResult =
-  | { ok: true; counts: DatabaseMutationCounts }
+  | {
+      ok: true;
+      counts: DatabaseMutationCounts;
+      /**
+       * Records this run declined to write because a subject is suppressed.
+       * Required on the success shape so a caller that reports the run cannot
+       * report it as fully applied without seeing what was withheld.
+       */
+      suppressedSkips: readonly SuppressedSkip[];
+    }
   | { ok: false; error: string };
 
 export type ImportArtifactsCommandInput = {
@@ -1136,6 +1147,7 @@ async function writeDatabaseMutationsStage(
     context.rows,
     context.resolvedMappings,
   );
+  const suppressedSkips = context.databaseResult.operations.suppressedSkips;
   const databaseMutations = dataContext.toDatabaseMutations({
     namespace: context.artifacts.metadata.namespace,
     name: context.commandName,
@@ -1146,6 +1158,9 @@ async function writeDatabaseMutationsStage(
     ...(context.artifactMutation.applied
       ? { artifactMutation: context.artifactMutation.reference }
       : {}),
+    // Omitted rather than written empty so a clean import produces the same
+    // envelope it always did, and the field's presence means something.
+    ...(suppressedSkips.length > 0 ? { suppressedSkips } : {}),
   });
   await mkdir(context.commandInput.commandDirectory, { recursive: true });
   databaseMutations.spec.mutations =
@@ -1164,6 +1179,12 @@ async function writeDatabaseMutationsStage(
     { databaseMutationsPath: databaseMutationsEnvelope.path },
     "DatabaseMutations envelope written.",
   );
+  if (suppressedSkips.length > 0) {
+    context.commandInput.logger?.info(
+      suppressedSkipLogFields(suppressedSkips),
+      "Records skipped because a subject is suppressed.",
+    );
+  }
   context.commandInput.logger?.info(
     context.commandInput.dryImport === true
       ? "Dry run enabled; database create/read/update skipped."
@@ -1228,7 +1249,11 @@ export async function importArtifacts(
         "DatabaseMutations pipeline finished without mutation counts.",
       );
     }
-    return { ok: true, counts: context.databaseMutationCounts };
+    return {
+      ok: true,
+      counts: context.databaseMutationCounts,
+      suppressedSkips: context.databaseResult?.operations.suppressedSkips ?? [],
+    };
   } catch (error) {
     return { ok: false, error: errorMessage(error) };
   }

--- a/src/cli/import/artifacts/data-context.ts
+++ b/src/cli/import/artifacts/data-context.ts
@@ -11,7 +11,11 @@ import {
   readLocationPathByPath,
   readPlaceLocationPathsContainingPoint,
 } from "../../database/location-paths.js";
-import type { ImportOperation, ImportOperations } from "./operations.js";
+import type {
+  ImportOperation,
+  ImportOperations,
+  SuppressedSkip,
+} from "./operations.js";
 import {
   type AgencyOfficerRow,
   type AgencyRow,
@@ -135,6 +139,7 @@ export type DatabaseMutationsMetadataInput = {
   sourceArtifactsDigest?: string;
   artifactMutation?: { path: string; digest: string };
   databaseSchema?: Record<string, unknown>;
+  suppressedSkips?: readonly SuppressedSkip[];
 };
 
 type OwnedColumnsMetadata = {

--- a/src/cli/import/artifacts/index.ts
+++ b/src/cli/import/artifacts/index.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { Command } from "commander";
 import { importArtifacts, type ImportArtifactsResult } from "./config.js";
 import { formatDatabaseMutationCountLines } from "./io/DatabaseMutationCounts.js";
+import { formatSuppressedSkipLines } from "./suppressed-skips.js";
 import { createIntakeLog } from "../../../logging.js";
 import { createCommandDirectory } from "../../command-directory.js";
 import type {
@@ -144,6 +145,7 @@ export async function runImportArtifactsCommand(
       artifactsPath: artifactsRef,
       databaseMutations: result.counts.mutations,
       recordsByEntityType: result.counts.recordsByEntityType,
+      suppressedSkipCount: result.suppressedSkips.length,
     },
     "Artifacts import succeeded.",
   );
@@ -155,6 +157,10 @@ export async function runImportArtifactsCommand(
         ? "Created DatabaseMutations envelope. Database apply skipped."
         : "Imported artifact database records.",
       ...formatDatabaseMutationCountLines(result.counts),
+      // Printed with the counts, not buried in the log file: an operator
+      // reading "Imported artifact database records" needs to see in the same
+      // breath which records were deliberately left alone.
+      ...formatSuppressedSkipLines(result.suppressedSkips),
       "",
     ].join("\n"),
   };

--- a/src/cli/import/artifacts/io/DatabaseMutations.ts
+++ b/src/cli/import/artifacts/io/DatabaseMutations.ts
@@ -91,9 +91,32 @@ const metadataSchema = z
       .strict()
       .optional(),
     databaseSchema: z.record(z.string(), z.unknown()).optional(),
+    // Records this import declined to update because a subject is under an
+    // active suppression. Carried on the envelope, not only in the run log,
+    // because the envelope is the artifact that outlives the run and gets
+    // diffed against the next one. Optional so envelopes written before this
+    // field existed still parse; absent and empty both mean "nothing skipped".
+    suppressedSkips: z
+      .array(
+        z
+          .object({
+            entity: z.enum(["agency", "personnel", "agencyPersonnel"]),
+            recordId: z.string().trim().min(1),
+            suppressedSubjectIds: z
+              .array(z.string().trim().min(1))
+              .min(1)
+              .readonly(),
+            withheldColumns: z
+              .array(z.string().trim().min(1))
+              .min(1)
+              .readonly(),
+          })
+          .strict(),
+      )
+      .readonly()
+      .optional(),
   })
   .strict();
-
 
 export const databaseMutationReferenceSchema = z
   .object({

--- a/src/cli/import/artifacts/operations.ts
+++ b/src/cli/import/artifacts/operations.ts
@@ -9,6 +9,30 @@ export type ImportOperations = {
   agencyOfficers: Record<string, ImportOperation>;
 };
 
+export type SuppressedSkipEntity = "agency" | "personnel" | "agencyPersonnel";
+
+/**
+ * One record the import declined to update because a subject it touches is
+ * under an active suppression.
+ *
+ * Without this, the demotion in classifyDatabaseOperations is indistinguishable
+ * from "this record had nothing to write": both land on `read`. An honoured
+ * takedown has to be legible in the change diff, not inferable from an absence.
+ */
+export type SuppressedSkip = {
+  entity: SuppressedSkipEntity;
+  /** Canonical ID of the record whose write was skipped. */
+  recordId: string;
+  /**
+   * Suppressed subject IDs that caused the skip. Usually `[recordId]`, but an
+   * agency-personnel link is skipped when the link, the person, or the agency
+   * is suppressed, so the identity of the skip is not always the record's own.
+   */
+  suppressedSubjectIds: readonly string[];
+  /** Columns this import owned and would have written. This is the "what changed" that did not. */
+  withheldColumns: readonly string[];
+};
+
 export type DatabaseRowOperations = {
   locationPaths: Record<string, "create" | "read">;
   locationPathGeometries: Record<string, "create" | "read">;
@@ -16,4 +40,10 @@ export type DatabaseRowOperations = {
   agencies: Record<string, "create" | "read" | "update">;
   officers: Record<string, "create" | "read" | "update">;
   agencyOfficers: Record<string, "create" | "read" | "update">;
+  /**
+   * Required, not optional: a consumer that forgets to read this reports a
+   * clean import that silently dropped a record. Classification always
+   * populates it, empty when nothing was suppressed.
+   */
+  suppressedSkips: SuppressedSkip[];
 };

--- a/src/cli/import/artifacts/suppressed-skips.ts
+++ b/src/cli/import/artifacts/suppressed-skips.ts
@@ -1,0 +1,50 @@
+import type { SuppressedSkip } from "./operations.js";
+
+/**
+ * Reporting the records an import declined to write because a subject is
+ * suppressed.
+ *
+ * Every load is supposed to produce a change diff explaining what changed and
+ * why. A record we chose not to update is part of that diff: it is the one
+ * case where the database and the source disagree on purpose. Left unreported,
+ * a honoured takedown is indistinguishable from a no-op, and the next person
+ * to compare source to database reads it as drift.
+ */
+
+const entityLabels: Record<SuppressedSkip["entity"], string> = {
+  agency: "Agency",
+  personnel: "Personnel",
+  agencyPersonnel: "AgencyPersonnel",
+};
+
+/**
+ * Identity is not optional here. A count alone tells an operator that
+ * something was withheld but not which record, and "which record" is exactly
+ * what a correction or an audit needs. Full list, no truncation: the number of
+ * active suppressions is small by construction, and a summary that silently
+ * cut off at ten would be the same failure this reporting exists to fix.
+ */
+export function formatSuppressedSkipLines(
+  skips: readonly SuppressedSkip[],
+): string[] {
+  if (skips.length === 0) {
+    return [];
+  }
+  return [
+    `Records skipped because a subject is suppressed: ${skips.length}`,
+    ...skips.map((skip) => {
+      const cause = skip.suppressedSubjectIds.includes(skip.recordId)
+        ? "suppressed"
+        : `suppressed via ${skip.suppressedSubjectIds.join(", ")}`;
+      return `  ${entityLabels[skip.entity]} ${skip.recordId} (${cause}); withheld: ${skip.withheldColumns.join(", ")}`;
+    }),
+  ];
+}
+
+/** Structured form for the log record, which is what an audit reads later. */
+export function suppressedSkipLogFields(skips: readonly SuppressedSkip[]): {
+  suppressedSkipCount: number;
+  suppressedSkips: readonly SuppressedSkip[];
+} {
+  return { suppressedSkipCount: skips.length, suppressedSkips: skips };
+}

--- a/test/import/artifacts-command.test.ts
+++ b/test/import/artifacts-command.test.ts
@@ -768,6 +768,42 @@ describe("importArtifacts", () => {
     expect(agencyMutation).not.toHaveProperty("ownedColumns");
     expect(agencyMutation).not.toHaveProperty("target");
     expect(agencyMutation?.kind).toBe("AgencyCreate");
+    // A clean import writes no suppressedSkips key at all, so the field's
+    // presence in an envelope always means something was withheld.
+    expect(parsedImportArtifacts.metadata).not.toHaveProperty(
+      "suppressedSkips",
+    );
+  });
+
+  test("DatabaseMutations envelope carries suppressed skips through a write and read", async () => {
+    const rootDir = await mkdtemp(path.join(tmpdir(), "intake-run-"));
+    const runId = "suppressed-skip-envelope";
+    const commandDirectory = path.join(rootDir, "intake", "commands", runId);
+    const suppressedSkips = [
+      {
+        entity: "personnel" as const,
+        recordId: "personnel-canonical-id",
+        suppressedSubjectIds: ["personnel-canonical-id"],
+        withheldColumns: ["last_name", "slug"],
+      },
+    ];
+
+    const written = await DatabaseMutations.write(
+      commandDirectory,
+      new DataContext({
+        rows,
+        operations: createOperations,
+      }).toDatabaseMutations({
+        namespace: "mn-post",
+        name: runId,
+        suppressedSkips,
+      }),
+    );
+
+    // Read back from disk, not from the in-memory object: the envelope is the
+    // artifact the next run diffs against, so the skip has to survive YAML.
+    const parsed = await DatabaseMutations.read(written.path);
+    expect(parsed.metadata.suppressedSkips).toEqual(suppressedSkips);
   });
 
   test("persists and reuses resolved agency and personnel slugs", async () => {
@@ -1119,6 +1155,7 @@ describe("importArtifacts", () => {
           Personnel: 1,
         },
       },
+      suppressedSkips: [],
     });
     const databaseMutations = await DatabaseMutations.read(
       path.join(
@@ -1286,6 +1323,7 @@ describe("importArtifacts", () => {
           LocationPathGeometry: 1,
         },
       },
+      suppressedSkips: [],
     });
     const databaseMutations = await DatabaseMutations.read(
       path.join(
@@ -1826,6 +1864,7 @@ describe("importArtifacts", () => {
             Personnel: 2,
           },
         },
+        suppressedSkips: [],
       }),
     });
 
@@ -1918,6 +1957,7 @@ describe("importArtifacts", () => {
               Personnel: 2,
             },
           },
+          suppressedSkips: [],
         };
       },
     });
@@ -1933,6 +1973,94 @@ describe("importArtifacts", () => {
     expect(result.stdout).toContain("Database mutations: 15");
     expect(result.stdout).toContain("LocationPath: 4");
     expect(result.stdout).toContain("LocationPathAlias: 5");
+  });
+
+  test("CLI reports the count and identity of records skipped because they are suppressed", async () => {
+    const rootDir = await mkdtemp(path.join(tmpdir(), "intake-suppressed-"));
+    const workspace = path.join(rootDir, "workspace");
+    const artifactsPath = path.join(
+      workspace,
+      "mn-post",
+      "commands",
+      "test-run",
+      "artifacts.yaml",
+    );
+
+    const result = await runImportArtifactsCommand(artifactsPath, {
+      env: { INTAKE_WORKSPACE: workspace },
+      now: new Date("2026-06-10T00:00:00.000Z"),
+      createCommandName: () => "tz4a98xxat96iws9zmbrgj3a",
+      terminal: { write: () => {} },
+      importArtifacts: async () => ({
+        ok: true,
+        counts: { mutations: 1, recordsByEntityType: { Agency: 1 } },
+        suppressedSkips: [
+          {
+            entity: "personnel",
+            recordId: "personnel-canonical-id",
+            suppressedSubjectIds: ["personnel-canonical-id"],
+            withheldColumns: ["last_name", "slug"],
+          },
+          {
+            entity: "agencyPersonnel",
+            recordId: "agency-personnel-canonical-id",
+            suppressedSubjectIds: ["personnel-canonical-id"],
+            withheldColumns: ["badge_number"],
+          },
+        ],
+      }),
+    });
+
+    const logPath = path.join(
+      workspace,
+      "intake",
+      "commands",
+      "2026-06-10T00-00-00-000Z-tz4a98xxat96iws9zmbrgj3a",
+      "tz4a98xxat96iws9zmbrgj3a.log",
+    );
+    const logLines = (await readFile(logPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(result.exitCode).toBe(0);
+    // The count, so an operator knows the scale.
+    expect(result.stdout).toContain(
+      "Records skipped because a subject is suppressed: 2",
+    );
+    // The identity, so they know which record to look up if it is disputed.
+    expect(result.stdout).toContain(
+      "  Personnel personnel-canonical-id (suppressed); withheld: last_name, slug",
+    );
+    expect(result.stdout).toContain(
+      "  AgencyPersonnel agency-personnel-canonical-id (suppressed via personnel-canonical-id); withheld: badge_number",
+    );
+    expect(logLines).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          msg: "Artifacts import succeeded.",
+          suppressedSkipCount: 2,
+        }),
+      ]),
+    );
+  });
+
+  test("CLI reports no suppressed-skip line when nothing was suppressed", async () => {
+    const rootDir = await mkdtemp(path.join(tmpdir(), "intake-suppressed-"));
+    const workspace = path.join(rootDir, "workspace");
+
+    const result = await runImportArtifactsCommand("artifacts.yaml", {
+      env: { INTAKE_WORKSPACE: workspace },
+      terminal: { write: () => {} },
+      importArtifacts: async () => ({
+        ok: true,
+        counts: { mutations: 1, recordsByEntityType: { Agency: 1 } },
+        suppressedSkips: [],
+      }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain("skipped because a subject is");
   });
 
   test("CLI honors LOG_LEVEL for observable debug logging", async () => {
@@ -1957,6 +2085,7 @@ describe("importArtifacts", () => {
         return {
           ok: true,
           counts: { mutations: 0, recordsByEntityType: {} },
+          suppressedSkips: [],
         };
       },
     });

--- a/test/import/artifacts/plan-database-mutations.test.ts
+++ b/test/import/artifacts/plan-database-mutations.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../src/cli/import/artifacts/plan-database-mutations.js";
 import { AgencyCreate } from "../../../src/cli/import/artifacts/io/generated-mutations/AgencyCreate.js";
 import { type ImportOperations } from "../../../src/cli/import/artifacts/operations.js";
+import { formatSuppressedSkipLines } from "../../../src/cli/import/artifacts/suppressed-skips.js";
 import type {
   ImportRows,
   LocationPathGeometryRow,
@@ -97,6 +98,29 @@ const rows: ImportRows = {
     },
   },
 };
+
+/** Every canonical row in `rows` already present in the database. */
+const existingCanonicalRecordResponses = [
+  {
+    pattern: /select \* from public\.agency\b/i,
+    rows: [{ ...rows.agencies[0], name: "Old Agency Name" }],
+  },
+  {
+    pattern: /select \* from public\.officers\b/i,
+    rows: [rows.officers[0]],
+  },
+  {
+    pattern: /select \* from public\.agency_officers\b/i,
+    rows: [rows.agencyOfficers[0]],
+  },
+];
+
+function suppressionResponse(subjectIds: readonly string[]) {
+  return {
+    pattern: /from public\.subject_suppression\b/i,
+    rows: subjectIds.map((subject_id) => ({ subject_id })),
+  };
+}
 
 const createOperations: ImportOperations = {
   locationPaths: {},
@@ -901,6 +925,149 @@ describe("planDatabaseMutations", () => {
     expect(client.queries.map(({ text }) => text.toLowerCase())).toContain(
       "rollback",
     );
+  });
+
+  test("an import with no suppressions reports no suppressed skips", async () => {
+    const client = new RecordingClient(undefined, undefined, [
+      ...existingCanonicalRecordResponses,
+    ]);
+
+    const result = await planDatabaseMutations(rows, {
+      env: { DATABASE_URL: "postgres://example/intake" },
+      clientFactory: () => client,
+    });
+
+    expect(result.operations.suppressedSkips).toEqual([]);
+    expect(
+      formatSuppressedSkipLines(result.operations.suppressedSkips),
+    ).toEqual([]);
+  });
+
+  test("a suppressed personnel record is skipped and named in the change diff", async () => {
+    const client = new RecordingClient(undefined, undefined, [
+      ...existingCanonicalRecordResponses,
+      suppressionResponse(["personnel-canonical-id"]),
+    ]);
+
+    const result = await planDatabaseMutations(rows, {
+      env: { DATABASE_URL: "postgres://example/intake" },
+      clientFactory: () => client,
+    });
+
+    // The agency is untouched by the suppression and still updates. Only the
+    // suppressed subject and the link that carries it are demoted.
+    expect(result.operations.agencies["agency-canonical-id"]).toBe("update");
+    expect(result.operations.officers["personnel-canonical-id"]).toBe("read");
+    expect(
+      result.operations.agencyOfficers["agency-personnel-canonical-id"],
+    ).toBe("read");
+
+    expect(result.operations.suppressedSkips).toEqual([
+      {
+        entity: "personnel",
+        recordId: "personnel-canonical-id",
+        suppressedSubjectIds: ["personnel-canonical-id"],
+        withheldColumns: [
+          "first_name",
+          "last_name",
+          "middle_name",
+          "prefix",
+          "suffix",
+          "slug",
+        ],
+      },
+      {
+        entity: "agencyPersonnel",
+        recordId: "agency-personnel-canonical-id",
+        // The link itself is not suppressed; the person it points at is. That
+        // distinction is the "why" the change diff has to carry.
+        suppressedSubjectIds: ["personnel-canonical-id"],
+        withheldColumns: [
+          "agency_id",
+          "personnel_id",
+          "badge_number",
+          "start_date",
+          "end_date",
+          "license_type",
+        ],
+      },
+    ]);
+
+    expect(
+      formatSuppressedSkipLines(result.operations.suppressedSkips),
+    ).toEqual([
+      "Records skipped because a subject is suppressed: 2",
+      "  Personnel personnel-canonical-id (suppressed); withheld: first_name, last_name, middle_name, prefix, suffix, slug",
+      "  AgencyPersonnel agency-personnel-canonical-id (suppressed via personnel-canonical-id); withheld: agency_id, personnel_id, badge_number, start_date, end_date, license_type",
+    ]);
+
+    expect(
+      client.queries.some(({ text }) => /update\s+public\./i.test(text)),
+    ).toBe(false);
+  });
+
+  test("a record with nothing to write is not counted as a suppressed skip", async () => {
+    // A suppressed record this import owns no columns on was always going to
+    // land on "read". Reporting it as a skipped takedown would overstate what
+    // suppression actually cost, which is the opposite of a truthful diff.
+    const unownedRows: ImportRows = {
+      ...rows,
+      ownedColumns: {
+        ...rows.ownedColumns,
+        officers: { "personnel-canonical-id": [] },
+        agencyOfficers: { "agency-personnel-canonical-id": [] },
+      },
+    };
+    const client = new RecordingClient(undefined, undefined, [
+      ...existingCanonicalRecordResponses,
+      suppressionResponse(["personnel-canonical-id"]),
+    ]);
+
+    const result = await planDatabaseMutations(unownedRows, {
+      env: { DATABASE_URL: "postgres://example/intake" },
+      clientFactory: () => client,
+    });
+
+    expect(result.operations.officers["personnel-canonical-id"]).toBe("read");
+    expect(result.operations.suppressedSkips).toEqual([]);
+  });
+
+  test("a suppressed agency also skips the links that hang off it", async () => {
+    const client = new RecordingClient(undefined, undefined, [
+      ...existingCanonicalRecordResponses,
+      suppressionResponse(["agency-canonical-id"]),
+    ]);
+
+    const result = await planDatabaseMutations(rows, {
+      env: { DATABASE_URL: "postgres://example/intake" },
+      clientFactory: () => client,
+    });
+
+    expect(result.operations.agencies["agency-canonical-id"]).toBe("read");
+    expect(result.operations.officers["personnel-canonical-id"]).toBe("update");
+    expect(
+      result.operations.agencyOfficers["agency-personnel-canonical-id"],
+    ).toBe("read");
+    expect(
+      result.operations.suppressedSkips.map(
+        ({ entity, recordId, suppressedSubjectIds }) => ({
+          entity,
+          recordId,
+          suppressedSubjectIds,
+        }),
+      ),
+    ).toEqual([
+      {
+        entity: "agency",
+        recordId: "agency-canonical-id",
+        suppressedSubjectIds: ["agency-canonical-id"],
+      },
+      {
+        entity: "agencyPersonnel",
+        recordId: "agency-personnel-canonical-id",
+        suppressedSubjectIds: ["agency-canonical-id"],
+      },
+    ]);
   });
 
   test("columns absent from artifacts ownership are left untouched", async () => {


### PR DESCRIPTION
Closes INS-37. Stacked on #61 (`ins9/corrections-takedown`) — that PR introduced the demotion this one makes visible. Merge #61 first.

## The problem

`classifyDatabaseOperations` demotes a suppressed row from `update` to `read`, so an honoured takedown costs one skipped record rather than an aborted import. Correct, but silent: a skipped record and a record with nothing to write both land on `read`. Every load is supposed to produce a change diff explaining what changed and why, and a skipped record is the one case where the database and the source disagree *on purpose*. Left unreported, it reads as drift to the next person who compares them.

## What changed

`DatabaseRowOperations` gains `suppressedSkips` — one entry per record whose write was withheld:

```ts
{ entity, recordId, suppressedSubjectIds, withheldColumns }
```

`suppressedSubjectIds` carries the why. An agency-personnel link is skipped when the link, the person, **or** the agency is suppressed, so the cause is not always the record's own ID.

Three deliberate calls:

- **The field is required, not optional.** A caller that reports a run cannot report it as clean without acknowledging what was withheld. This forced three call sites to handle it — that is the point, not a nuisance.
- **A record we own no columns on is not a skip.** It was always going to land on `read`. Counting it would overstate what suppression cost, which is the same category of untruth this change exists to fix.
- **Skips are keyed, not appended.** `rows.officers` is classified without the already-seen guard the agency loop has, so a record can be visited twice. A diff that double-counts a takedown is its own small lie.

Reported three ways: CLI stdout next to the mutation counts, the structured run log (`suppressedSkipCount` + full list), and `DatabaseMutations` envelope metadata — the last so the next run's diff can see it. The envelope key is omitted when nothing was skipped, so its presence always means something.

## Gap this does not close

A suppressed subject whose row does **not** exist is still planned as `create`. `enforce_entity_not_suppressed` fires on UPDATE and DELETE only, so that insert would succeed and re-create a suppressed subject under the same canonical ID. Reachable only if the row was deleted before the suppression was filed — the trigger blocks deleting a suppressed row. Narrow, but real. Filed as a follow-up rather than fixed here: closing it means either a database-side INSERT guard or a fourth planner outcome, and both are larger than this issue.

## Verification

- 156/156 pass across `test/import`, `test/architecture`, `test/cli`.
- New: 4 planner tests (personnel suppressed, agency suppressed cascading to its link, nothing-to-write not counted, no-suppression baseline), 2 CLI reporting tests, 1 envelope round-trip through YAML, 1 asserting a clean import writes no `suppressedSkips` key.
- `tsc --noEmit` clean, prettier clean.
- `test/seed-display.test.ts` fails in any fresh checkout — it reads `supabase/seed.sql`, which `npm run link-seed` creates and which is absent from the current working checkout too. Pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)