### PR TITLE
feat(sources): add Donut Operator YouTube channel as a coverage source (INS-46)

### DIFF
--- a/openspec/changes/add-youtube-coverage-source/design.md
+++ b/openspec/changes/add-youtube-coverage-source/design.md
@@ -1,0 +1,89 @@
+## Context
+
+The board supplied an ordered list of YouTube channels covering policing, ranked
+by subscriber count, and asked for rank 1 (Donut Operator, `@DonutOperator`,
+`UCwkm_Wcyh0pc7UUmZZfL-6w`, ~5.31M subscribers on 2026-08-24) to land as an
+intake source. The existing `sources/<namespace>` contract already provides
+everything needed structurally: an optional `acquire` phase for network work, a
+deterministic `run` phase, a declared `produces` set, and an `Artifacts` envelope
+that root intake validates record by record.
+
+The open questions were not mechanical. They were: what entity does a video
+become, what is the record's identity, and where does this source stop.
+
+## Decisions
+
+**Namespace per channel, reverse-DNS: `com.youtube.donutoperator`.**
+The queue is ranked by channel, and channels differ in editorial character,
+reliability, and access terms. A shared `youtube` namespace would fuse them into
+one provenance blob and make a per-channel takedown or suppression a filtering
+exercise. Per-channel namespaces make rank 2..n purely additive and keep the
+source-name ledger scoped the way ADR 0015 intends. Reverse-DNS matches
+`gov.tx.tcole` and the sibling producer repos.
+
+**A video is a `CoverageLink`, keyed by video ID.**
+`coverage_links` already models exactly this — a URL, a normalized URL, a title,
+a publication name, a publish date — and `CoverageLinks` is registered with
+`dependsOn: []`, so this source needs no pipeline change and no new kind. The
+YouTube video ID is globally unique and permanent, which makes it both the
+source-local record key and the basis for `normalized_url`. Building the URL
+from the ID rather than passing through whatever URL form the API returned means
+there is no share-link, playlist-context, or tracking-parameter variance for the
+`coverage_links_normalized_url_key` unique index to trip over.
+
+`contentDetails.videoPublishedAt` is the publish time; `snippet.publishedAt` on a
+playlist item is when the video was _added to the uploads playlist_. They are
+usually close and occasionally are not. `published_at` takes the former.
+
+**The source stops at the coverage record.**
+The tempting next step is to attach each video to the officer it discusses. This
+source cannot do that correctly: YouTube gives it a stable ID for the _video_ and
+nothing at all for the _person_, so any link would come from matching a name out
+of a title or description written for an audience, not a records system. A wrong
+attachment here is a claim that a named officer was the subject of a named piece
+of commentary — the exact failure mode the project treats as unacceptable.
+
+Rather than leave that as a comment, the constraint is enforced by the contract
+already in place: `produces: ["CoverageLinks"]`, and `runSource` aborts on any
+emitted kind not in `produces`. Emitting `CoverageLinkAgencyOfficers` from this
+namespace is a failed run.
+
+**Identity checks run in both phases.**
+`acquire` verifies the channel ID against `channels.list`; `run` re-verifies the
+acquired `channel.json` and every playlist item's `snippet.channelId`. The second
+check is not redundant: archived snapshots are replayable without `acquire`, and
+the identity guarantee has to survive that path. Handle and title drift is logged
+and recorded instead — those are labels, and a rename is information, not a fault.
+
+## Alternatives Considered
+
+- **A generic `youtube` source parameterized by a channel list.** Rejected for
+  now: one channel is in scope, and a per-channel namespace is the unit the
+  ranking, provenance, and any future suppression actually operate on. If ranks
+  2..n prove to be pure copies, the shared logic can be lifted into
+  `sources/lib/` the way `civil-defendants.ts` was — without collapsing the
+  namespaces.
+- **Emitting officer links behind a confidence field.** Rejected. The
+  `coverage_link_agency_officers.confidence` column exists, but a low-confidence
+  value on a wrong row is still a wrong row, and nothing downstream is obliged to
+  read it. The gate belongs at emission.
+- **Scraping the channel page or an RSS feed to avoid the API key.** Rejected.
+  YouTube's terms prohibit scraping, and the Data API is free within the default
+  quota — a full channel re-pull costs one unit per 50-item page against a
+  10,000-unit daily budget. There is no reason to take the disallowed path.
+- **Ingesting video descriptions and transcripts as record text.** Out of scope.
+  That is third-party commentary about named people; storing it as a field on our
+  records is a publication-risk decision, not an engineering one.
+
+## Risks / Open Questions
+
+- **The channel ID is board-supplied and has not been verified against YouTube.**
+  Verification requires a `YOUTUBE_API_KEY`, which is not yet provisioned, so the
+  first `acquire` is the check — and it fails loudly if `channels.list` does not
+  return exactly that channel.
+- **Refresh policy is unspecified.** Each `acquire` writes a full snapshot with
+  its own digest; how often a channel is re-pulled, and whether an upload that
+  disappears from the playlist should be suppressed rather than simply absent
+  from the next run, is not decided here.
+- **Whether this coverage is ever publicly rendered is not an engineering call.**
+  Nothing in this change publishes anything.

--- a/openspec/changes/add-youtube-coverage-source/proposal.md
+++ b/openspec/changes/add-youtube-coverage-source/proposal.md
@@ -1,0 +1,103 @@
+## Why
+
+Every source in `sources/` today is a records source: a POST roster, a court
+docket API, a census file. The board has asked for a subscriber-ranked queue of
+YouTube channels that cover policing incidents, starting with Donut Operator
+(~5.31M subscribers on 2026-08-24, rank 1).
+
+That is a different kind of source, and the difference is the whole point of
+writing this down. A POST roster is a record _of_ an officer's employment. A
+YouTube video is one person's commentary _about_ an incident. Both are useful;
+only the first can support a claim about a named human being. If a media source
+lands in `sources/` without that distinction stated in a durable spec, the next
+person to touch it has no reason not to parse officer names out of video titles
+and write `CoverageLinkAgencyOfficer` rows — which is precisely how a police
+accountability database attaches the wrong person to the wrong incident.
+
+So this change adds the source and, in the same breath, specifies the ceiling on
+what a media-channel source is allowed to emit.
+
+## What Changes
+
+**A per-channel media source namespace**
+
+- From: no media/commentary source exists; `sources/` holds records sources only.
+- To: `sources/com.youtube.donutoperator/` with the standard `acquire` (network)
+  and `run` (deterministic) phases, emitting `CoverageLinks` — one per public
+  upload, keyed by the YouTube video ID.
+- Reason: the intake-source queue is ordered by channel, so the namespace is the
+  channel. Reverse-DNS (`com.youtube.<channel>`) matches `gov.tx.tcole` and
+  keeps rank 2..n additive rather than a shared `youtube` grab bag.
+- Impact: additive. `CoverageLinks` has `dependsOn: []` and is already wired
+  through the pipeline (mn-post emits it), so no registry, schema, migration, or
+  envelope change is required.
+
+**Identity is the channel ID, never the handle or the display name**
+
+- From: n/a.
+- To: `channel.ts` pins `UCwkm_Wcyh0pc7UUmZZfL-6w`. `acquire` resolves the
+  channel by ID through `channels.list` and fails if the API returns anything
+  else. `run` re-checks the acquired `channel.json` and rejects any playlist item
+  whose `snippet.channelId` is not the pinned ID.
+- Reason: a handle (`@DonutOperator`) and a title are labels the channel owner
+  can change or release to someone else; the channel ID cannot change. Drift in
+  either label is logged as evidence, not treated as a failure — a rename must
+  not silently repoint ingestion at a different channel, and must not break it
+  either.
+- Impact: the source has no name-matching code path to regress into.
+
+**A media source emits coverage, not associations**
+
+- From: n/a — no rule stated.
+- To: the source declares `produces: ["CoverageLinks"]` and nothing else. The
+  run command already rejects any undeclared emitted kind, so
+  `CoverageLinkAgencyOfficers` from this namespace is a hard failure, not a
+  review comment.
+- Reason: this source has no stable officer identifier. Linking a video to a
+  named officer would require matching a person out of a title or description —
+  display-name matching against named human beings, with no way to be right
+  reliably.
+- Impact: coverage from this channel is catalogued and attributable to the
+  video, and attaches to no personnel record until a reviewed mechanism exists.
+
+**Sanctioned access only**
+
+- From: n/a.
+- To: `acquire` reads the YouTube Data API v3 (`channels.list`,
+  `playlistItems.list`) with `YOUTUBE_API_KEY`, preserves every raw response
+  unchanged, and retries only 429/5xx. A 403 (quota exhausted or bad key) fails
+  immediately.
+- Reason: YouTube's terms prohibit scraping the site; the Data API is the
+  channel it offers, and it is free within the default quota. Retrying a 403 is
+  working around a limit rather than respecting it.
+- Impact: the source cannot run without an API key, and fails loudly saying so.
+
+## Capabilities
+
+### New Capabilities
+
+- `youtube-coverage-source`: a per-channel YouTube media source that resolves by
+  channel ID, acquires through the YouTube Data API v3 into a preserved raw
+  snapshot, and deterministically emits one `CoverageLink` per public upload
+  keyed by video ID — while being structurally barred from emitting personnel
+  associations.
+
+### Modified Capabilities
+
+<!-- None. `config-driven-source-import` and the run-order contract are used as
+specified; no existing requirement changes. -->
+
+## Impact
+
+- **New code**: `sources/com.youtube.donutoperator/{channel,acquire,run}.ts`;
+  `test/sources/com.youtube.donutoperator/run.test.ts`.
+- **Modified code**: none. `CoverageLinks` is an existing registered kind with
+  `dependsOn: []`, already read, transformed, and persisted by the pipeline.
+- **Env**: new `YOUTUBE_API_KEY`, required for `intake acquire`, unused by
+  `intake run`.
+- **No** migration, seed change, generated-type change, or dependency addition.
+- **Cost**: none. The YouTube Data API's free quota (10,000 units/day) covers a
+  full channel re-pull; `playlistItems.list` costs 1 unit per 50-item page.
+- **Out of scope**: linking coverage to officers or civil cases; ranks 2..n of
+  the channel queue; any public rendering of this data; retention/refresh policy
+  for re-acquiring a channel.

--- a/openspec/changes/add-youtube-coverage-source/specs/youtube-coverage-source/spec.md
+++ b/openspec/changes/add-youtube-coverage-source/specs/youtube-coverage-source/spec.md
@@ -1,0 +1,134 @@
+## ADDED Requirements
+
+### Requirement: A YouTube channel source is identified by its channel ID
+
+A YouTube source namespace MUST pin the channel's YouTube channel ID and MUST
+resolve the channel by that ID alone. The handle and display name MUST be
+recorded as provenance and MUST NOT be used to select, search for, or confirm
+which channel is ingested. `acquire` MUST fail when `channels.list` for the
+pinned ID does not return exactly that channel. `run` MUST fail when the
+acquired channel record is not exactly the pinned channel, so the guarantee also
+holds when an archived snapshot is replayed without `acquire`.
+
+#### Scenario: the pinned channel is the Donut Operator channel ID
+
+- **WHEN** the `com.youtube.donutoperator` source resolves its channel
+- **THEN** it resolves to channel ID `UCwkm_Wcyh0pc7UUmZZfL-6w`
+
+#### Scenario: a snapshot for a different channel is rejected
+
+- **WHEN** `run` reads a `channel.json` whose single item's `id` is not the
+  pinned channel ID
+- **THEN** `run` throws naming the pinned channel ID, and emits no records
+
+#### Scenario: a foreign upload in the snapshot is rejected
+
+- **WHEN** an uploads page contains an item whose `snippet.channelId` is not the
+  pinned channel ID
+- **THEN** `run` throws naming the unexpected channel ID, and emits no records
+
+#### Scenario: a renamed handle is evidence, not a failure
+
+- **WHEN** `acquire` observes a `snippet.customUrl` that differs from the pinned
+  handle
+- **THEN** the drift is logged and written to the snapshot's provenance record
+- **AND** the acquire completes against the pinned channel ID
+
+### Requirement: Channel provenance is preserved with every acquire
+
+Each `acquire` MUST write a provenance record alongside the preserved raw
+responses capturing the pinned channel ID, handle, canonical channel URL, and
+display name; the handle and title observed at retrieval; the uploads playlist
+ID; the subscriber count observed at retrieval; the board-provided
+subscriber-count snapshot and queue rank; the access method; and the retrieval
+timestamp. Raw API responses MUST be preserved unchanged.
+
+#### Scenario: the board's rank-1 snapshot is preserved
+
+- **WHEN** the `com.youtube.donutoperator` source records its queue position
+- **THEN** it carries rank `1` with subscriber count `5310000` retrieved on
+  `2026-08-24`
+
+#### Scenario: an acquire records its retrieval
+
+- **WHEN** `acquire` completes
+- **THEN** the snapshot contains the unmodified `channels.list` response, every
+  unmodified `playlistItems.list` page, and a provenance record naming the
+  channel ID, the observed subscriber count, the access method, and the
+  retrieval timestamp
+
+### Requirement: One CoverageLink per public upload, keyed by video ID
+
+`run` MUST emit exactly one `CoverageLink` record per public upload in the
+snapshot, keyed by the YouTube video ID. `url` and `normalized_url` MUST both be
+the canonical watch URL built from that video ID, `title` the video title,
+`source_name` the channel's pinned display name, and `published_at` the video's
+publish time (`contentDetails.videoPublishedAt` — when the video was published,
+not when it was added to the uploads playlist).
+
+#### Scenario: a public upload becomes a CoverageLink
+
+- **WHEN** the snapshot contains a public upload with video ID `dQw4w9WgXcQ`,
+  title `Officer body camera released`, and `videoPublishedAt`
+  `2026-01-15T18:30:00Z`
+- **THEN** a `CoverageLink` record keyed `dQw4w9WgXcQ` is emitted with `url` and
+  `normalized_url` both `https://www.youtube.com/watch?v=dQw4w9WgXcQ`, `title`
+  `Officer body camera released`, `source_name` `Donut Operator`, and
+  `published_at` `2026-01-15T18:30:00Z`
+
+#### Scenario: private and deleted uploads are skipped with a count
+
+- **WHEN** an uploads page contains items whose `status.privacyStatus` is not
+  `public`, or that are missing a video ID, title, or publish date
+- **THEN** no record is emitted for them
+- **AND** the run logs how many were skipped for each reason
+
+#### Scenario: run is deterministic
+
+- **WHEN** `run` executes twice over the same snapshot
+- **THEN** the two returned manifests are deep-equal
+
+#### Scenario: the artifacts are accepted by root intake
+
+- **WHEN** the emitted manifest is built into an `Artifacts` envelope and read
+  back through `Artifacts.read` with `includeKinds: ["CoverageLinks"]`
+- **THEN** the read succeeds and every record validates against `CoverageLinkSpec`
+
+### Requirement: A media source emits no personnel associations
+
+A YouTube channel source MUST declare `produces: ["CoverageLinks"]` and MUST NOT
+emit `CoverageLinkAgencyOfficers` or any other kind that attaches coverage to a
+named person. Commentary about an incident is not a record of an officer's
+conduct, and this source carries no stable officer identifier, so any link from
+one of its videos to a named officer would rest on matching a person out of free
+text. Attaching this coverage to personnel requires a separate reviewed
+mechanism and is out of scope for the source.
+
+#### Scenario: the declared produced kinds are coverage only
+
+- **WHEN** the source module's `produces` export is read
+- **THEN** it is exactly `["CoverageLinks"]`
+
+#### Scenario: an officer association would fail the run
+
+- **WHEN** the source emits a `CoverageLinkAgencyOfficers` artifact
+- **THEN** the run command aborts reporting the undeclared kind, and nothing is
+  imported
+
+### Requirement: Acquisition uses YouTube's sanctioned API within its quota
+
+`acquire` MUST read the YouTube Data API v3 and MUST NOT scrape youtube.com. It
+MUST require an API key and fail loudly when it is absent. It MAY retry
+throttling (429) and transient server errors (5xx) with capped backoff, and MUST
+NOT retry a 403 — the status YouTube returns for an exhausted quota or an
+invalid key — because retrying it evades a limit rather than respecting it.
+
+#### Scenario: a missing API key fails before any request
+
+- **WHEN** `acquire` runs without `YOUTUBE_API_KEY` set
+- **THEN** it throws naming `YOUTUBE_API_KEY`, and issues no HTTP request
+
+#### Scenario: quota exhaustion stops the acquire
+
+- **WHEN** the API responds `403`
+- **THEN** `acquire` fails immediately without retrying

--- a/openspec/changes/add-youtube-coverage-source/tasks.md
+++ b/openspec/changes/add-youtube-coverage-source/tasks.md
@@ -1,0 +1,53 @@
+> **Updated 2026-08-24.** Source, spec, and tests are landed and green. The one
+> remaining item (1.5) is a real `intake acquire` against the YouTube Data API,
+> which needs a `YOUTUBE_API_KEY` that is not yet provisioned.
+
+## 1. Source module
+
+- [x] 1.0 `sources/com.youtube.donutoperator/channel.ts`: pin channel ID
+      `UCwkm_Wcyh0pc7UUmZZfL-6w`, handle `@DonutOperator`, canonical URL, display
+      name, and the board's rank-1 subscriber snapshot (5,310,000 on 2026-08-24).
+      `watchUrl()` builds the canonical watch URL from a video ID.
+- [x] 1.1 `acquire.ts`: YouTube Data API v3. Require `YOUTUBE_API_KEY`; resolve
+      by `channels.list?id=<pinned>` and fail unless exactly that channel comes
+      back; write the raw response to `channel.json`; page
+      `playlistItems.list?part=snippet,contentDetails,status` over the uploads
+      playlist into `uploads-NNNN.json`; write `provenance.json`. Retry 429/5xx
+      with capped backoff; never retry 403.
+- [x] 1.2 `run.ts`: `produces: ["CoverageLinks"]`. Re-verify `channel.json` is
+      the pinned channel and every item's `snippet.channelId` matches; emit one
+      `CoverageLink` per public upload keyed by video ID (`url` =
+      `normalized_url` = canonical watch URL, `published_at` =
+      `contentDetails.videoPublishedAt`, `source_name` = pinned display name);
+      skip non-public and incomplete entries with a logged count. Deterministic:
+      no network, clock, or randomness.
+- [x] 1.3 Confirm no pipeline change is needed: `CoverageLinks` is registered
+      with `dependsOn: []`, has source facades in
+      `import/artifacts/config.ts`, entity handling in `data-context.ts`, and a
+      ledger entity block — mn-post already emits the kind.
+- [x] 1.4 Confirm the source registers: `intake sources` lists
+      `com.youtube.donutoperator [acquire, run]`, `produces: CoverageLinks`, and
+      no consumed kinds.
+- [ ] 1.5 Run a real `intake acquire com.youtube.donutoperator`, confirm the
+      pinned channel resolves and the observed subscriber count is in the range
+      of the board snapshot, and record the page/item counts.
+      _PENDING — requires a `YOUTUBE_API_KEY`._
+
+## 2. Tests
+
+- [x] 2.0 `test/sources/com.youtube.donutoperator/run.test.ts`: record shape and
+      key, determinism, private/deleted/incomplete skipping, wrong-channel
+      `channel.json` rejected, foreign-channel upload rejected, empty snapshot
+      rejected, `produces` is coverage-only, subscriber snapshot pinned.
+- [x] 2.1 Acceptance: build the manifest into an `Artifacts` envelope and read it
+      back through `Artifacts.read({ includeKinds: ["CoverageLinks"] })` — the
+      same call root intake makes, which validates every record against
+      `CoverageLinkSpec`.
+
+## 3. Validation
+
+- [x] 3.0 `npm run test:vitest`
+- [x] 3.1 `npm run typecheck`
+- [x] 3.2 `npm run format:check`
+- [x] 3.3 `npm run build`
+- [x] 3.4 `npm run openspec:validate`

--- a/sources/com.youtube.donutoperator/acquire.ts
+++ b/sources/com.youtube.donutoperator/acquire.ts
@@ -1,0 +1,202 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+  AcquireDeps,
+  SourceAcquire,
+} from "../../src/cli/run/source-run.js";
+import {
+  CHANNEL_DISPLAY_NAME,
+  CHANNEL_HANDLE,
+  CHANNEL_ID,
+  CHANNEL_URL,
+  SUBSCRIBER_SNAPSHOT,
+} from "./channel.js";
+
+/**
+ * Acquired through the YouTube Data API v3 — the access channel YouTube
+ * sanctions for this data. This source does not scrape youtube.com, does not
+ * touch pages the site's robots.txt disallows, and does not work around the
+ * API's quota.
+ */
+const API = "https://www.googleapis.com/youtube/v3";
+const PAGE_SIZE = 50;
+const MAX_RETRIES = 5;
+const MAX_BACKOFF_MS = 60_000;
+
+export const description =
+  "Downloads the Donut Operator channel record and every uploads playlist page from the YouTube Data API v3, preserved as raw JSON.";
+
+type ApiResponse = Record<string, unknown>;
+
+function str(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function first(response: ApiResponse): Record<string, unknown> | undefined {
+  const list = Array.isArray(response.items) ? response.items : [];
+  return list.length === 1 ? (list[0] as Record<string, unknown>) : undefined;
+}
+
+function pageFileName(pageNumber: number): string {
+  return `uploads-${String(pageNumber).padStart(4, "0")}.json`;
+}
+
+function backoffMs(attempt: number): number {
+  return Math.min(MAX_BACKOFF_MS, 1000 * 2 ** attempt);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Retries throttling (429) and transient server errors (5xx) with capped
+ * exponential backoff. A 403 is *not* retried: the YouTube API returns it for
+ * quota exhaustion and for a bad key, and retrying either one is just hammering
+ * a door that will not open until a human acts.
+ */
+async function fetchJson(url: string): Promise<ApiResponse> {
+  for (let attempt = 0; ; attempt += 1) {
+    const response = await fetch(url);
+    if (response.ok) {
+      return (await response.json()) as ApiResponse;
+    }
+    const body = await response.text();
+    const retryable = response.status === 429 || response.status >= 500;
+    if (!retryable || attempt >= MAX_RETRIES) {
+      throw new Error(
+        `com.youtube.donutoperator: YouTube API ${response.status} ${response.statusText}: ${body.slice(0, 500)}`,
+      );
+    }
+    await sleep(backoffMs(attempt));
+  }
+}
+
+function withKey(
+  pathname: string,
+  params: Record<string, string>,
+  key: string,
+): string {
+  const search = new URLSearchParams({ ...params, key });
+  return `${API}/${pathname}?${search.toString()}`;
+}
+
+export const acquire: SourceAcquire = async ({
+  sourceDir,
+  env,
+  logger,
+}: AcquireDeps) => {
+  const log = logger ?? { info() {} };
+  const apiKey = str(env.YOUTUBE_API_KEY);
+  if (apiKey === "") {
+    throw new Error(
+      "com.youtube.donutoperator: YOUTUBE_API_KEY is required to read the YouTube Data API v3.",
+    );
+  }
+  await mkdir(sourceDir, { recursive: true });
+
+  // Resolve by channel ID, never by handle or title search: the ID is the only
+  // identifier YouTube guarantees is stable for the life of the channel.
+  const channelResponse = await fetchJson(
+    withKey(
+      "channels",
+      { part: "snippet,contentDetails,statistics", id: CHANNEL_ID },
+      apiKey,
+    ),
+  );
+  const channel = first(channelResponse);
+  if (channel === undefined || str(channel.id) !== CHANNEL_ID) {
+    throw new Error(
+      `com.youtube.donutoperator: channels.list did not return exactly channel ${CHANNEL_ID}.`,
+    );
+  }
+  await writeFile(
+    path.join(sourceDir, "channel.json"),
+    JSON.stringify(channelResponse, null, 2),
+    "utf8",
+  );
+
+  const snippet = (channel.snippet ?? {}) as Record<string, unknown>;
+  const statistics = (channel.statistics ?? {}) as Record<string, unknown>;
+  const observedHandle = str(snippet.customUrl);
+  const observedTitle = str(snippet.title);
+  // A renamed handle or title is drift worth seeing, not a failure: identity is
+  // the channel ID, and ingestion must not break because a label moved.
+  if (observedHandle.toLowerCase() !== CHANNEL_HANDLE.toLowerCase()) {
+    log.info(
+      `com.youtube.donutoperator: handle drift — pinned ${CHANNEL_HANDLE}, channel now reports ${observedHandle || "(none)"}.`,
+    );
+  }
+  if (observedTitle !== CHANNEL_DISPLAY_NAME) {
+    log.info(
+      `com.youtube.donutoperator: display-name drift — pinned "${CHANNEL_DISPLAY_NAME}", channel now reports "${observedTitle}".`,
+    );
+  }
+
+  const relatedPlaylists = (
+    (channel.contentDetails ?? {}) as Record<string, unknown>
+  ).relatedPlaylists as Record<string, unknown> | undefined;
+  const uploadsPlaylistId = str(relatedPlaylists?.uploads);
+  if (uploadsPlaylistId === "") {
+    throw new Error(
+      `com.youtube.donutoperator: channel ${CHANNEL_ID} has no contentDetails.relatedPlaylists.uploads.`,
+    );
+  }
+
+  let pageToken = "";
+  let pageNumber = 0;
+  let itemCount = 0;
+  do {
+    pageNumber += 1;
+    const page = await fetchJson(
+      withKey(
+        "playlistItems",
+        {
+          part: "snippet,contentDetails,status",
+          playlistId: uploadsPlaylistId,
+          maxResults: String(PAGE_SIZE),
+          ...(pageToken === "" ? {} : { pageToken }),
+        },
+        apiKey,
+      ),
+    );
+    await writeFile(
+      path.join(sourceDir, pageFileName(pageNumber)),
+      JSON.stringify(page, null, 2),
+      "utf8",
+    );
+    itemCount += Array.isArray(page.items) ? page.items.length : 0;
+    pageToken = str(page.nextPageToken);
+  } while (pageToken !== "");
+
+  const retrievedAt = new Date().toISOString();
+  await writeFile(
+    path.join(sourceDir, "provenance.json"),
+    JSON.stringify(
+      {
+        channelId: CHANNEL_ID,
+        pinnedHandle: CHANNEL_HANDLE,
+        pinnedDisplayName: CHANNEL_DISPLAY_NAME,
+        channelUrl: CHANNEL_URL,
+        observedHandle,
+        observedTitle,
+        uploadsPlaylistId,
+        // YouTube rounds subscriberCount to three significant figures; this is
+        // ordering evidence for the intake-source queue, not a measurement.
+        observedSubscriberCount: str(statistics.subscriberCount),
+        boardSubscriberSnapshot: SUBSCRIBER_SNAPSHOT,
+        accessMethod: "YouTube Data API v3 (channels.list, playlistItems.list)",
+        retrievedAt,
+        pages: pageNumber,
+        items: itemCount,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  log.info(
+    `com.youtube.donutoperator: acquired ${itemCount} playlist item(s) across ${pageNumber} page(s) at ${retrievedAt}`,
+  );
+};

--- a/sources/com.youtube.donutoperator/channel.ts
+++ b/sources/com.youtube.donutoperator/channel.ts
@@ -1,0 +1,28 @@
+/**
+ * Pinned identity for the Donut Operator channel.
+ *
+ * The channel ID is the identity. The handle (`@DonutOperator`) and the display
+ * name are labels a channel owner can change at will, so they are recorded as
+ * provenance and checked for drift — never used to resolve which channel this
+ * source ingests.
+ */
+export const CHANNEL_ID = "UCwkm_Wcyh0pc7UUmZZfL-6w";
+export const CHANNEL_HANDLE = "@DonutOperator";
+export const CHANNEL_URL = "https://www.youtube.com/@DonutOperator";
+export const CHANNEL_DISPLAY_NAME = "Donut Operator";
+
+/**
+ * Board-provided rank in the subscriber-ordered intake-source queue, with the
+ * subscriber count that produced it. YouTube reports subscriber counts rounded
+ * to three significant figures, so this is a snapshot for ordering evidence,
+ * not a measured value.
+ */
+export const SUBSCRIBER_SNAPSHOT = {
+  rank: 1,
+  subscriberCount: 5_310_000,
+  retrievedOn: "2026-08-24",
+} as const;
+
+export function watchUrl(videoId: string): string {
+  return `https://www.youtube.com/watch?v=${videoId}`;
+}

--- a/sources/com.youtube.donutoperator/run.ts
+++ b/sources/com.youtube.donutoperator/run.ts
@@ -1,0 +1,152 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { ImportArtifactKind } from "../../src/shared/io/index.js";
+import type {
+  EmittedRecords,
+  RunDeps,
+  SourceRun,
+} from "../../src/cli/run/source-run.js";
+import { CHANNEL_DISPLAY_NAME, CHANNEL_ID, watchUrl } from "./channel.js";
+
+export const produces: readonly ImportArtifactKind[] = ["CoverageLinks"];
+
+/**
+ * Donut Operator uploads → one CoverageLink per public video, keyed by the
+ * YouTube video ID.
+ *
+ * This source catalogs media. It deliberately emits no
+ * `CoverageLinkAgencyOfficers`: attaching a video to a named officer would mean
+ * matching a person out of a video title or description, and this source has no
+ * stable officer identifier to match on. Linking coverage to named personnel is
+ * a separate, reviewed decision — not a byproduct of ingesting a channel.
+ *
+ * Deterministic: reads only the preserved acquire snapshot, no network, clock,
+ * or randomness.
+ */
+export const description =
+  "Donut Operator (YouTube @DonutOperator) — CoverageLink per public upload, keyed by video ID. Media catalog only; emits no officer associations.";
+
+type PlaylistItem = {
+  snippet?: {
+    title?: unknown;
+    channelId?: unknown;
+  };
+  contentDetails?: {
+    videoId?: unknown;
+    videoPublishedAt?: unknown;
+  };
+  status?: {
+    privacyStatus?: unknown;
+  };
+};
+
+type PlaylistItemsPage = { items?: unknown };
+type ChannelsResponse = { items?: unknown };
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function items(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? (value as Record<string, unknown>[]) : [];
+}
+
+/**
+ * The acquired `channel.json` must be the pinned channel. Re-checking here (and
+ * not only in acquire) means the identity guarantee survives replaying an
+ * archived snapshot, where acquire never runs.
+ */
+async function assertPinnedChannel(channelPath: string): Promise<void> {
+  const response = JSON.parse(
+    await readFile(channelPath, "utf8"),
+  ) as ChannelsResponse;
+  const ids = items(response.items).map((item) => text(item.id));
+  if (ids.length !== 1 || ids[0] !== CHANNEL_ID) {
+    throw new Error(
+      `com.youtube.donutoperator: ${path.basename(channelPath)} must describe exactly ` +
+        `channel ${CHANNEL_ID}, found [${ids.join(", ")}].`,
+    );
+  }
+}
+
+export const run: SourceRun = async ({ paths, logger }: RunDeps) => {
+  const log = logger ?? { info() {} };
+  const channelPaths = paths.filter(
+    (file) => path.basename(file) === "channel.json",
+  );
+  if (channelPaths.length !== 1) {
+    throw new Error(
+      `com.youtube.donutoperator: expected exactly one channel.json in the acquire ` +
+        `snapshot, found ${channelPaths.length}.`,
+    );
+  }
+  await assertPinnedChannel(channelPaths[0]);
+
+  const uploadPaths = paths
+    .filter((file) => /^uploads-\d+\.json$/.test(path.basename(file)))
+    .sort();
+  if (uploadPaths.length === 0) {
+    throw new Error(
+      "com.youtube.donutoperator: acquire snapshot has no uploads-NNNN.json pages.",
+    );
+  }
+
+  const records: EmittedRecords = {};
+  let nonPublic = 0;
+  let unusable = 0;
+
+  for (const uploadPath of uploadPaths) {
+    const page = JSON.parse(
+      await readFile(uploadPath, "utf8"),
+    ) as PlaylistItemsPage;
+    for (const raw of items(page.items)) {
+      const item = raw as PlaylistItem;
+      const videoId = text(item.contentDetails?.videoId);
+      const title = text(item.snippet?.title);
+      const publishedAt = text(item.contentDetails?.videoPublishedAt);
+      const privacyStatus = text(item.status?.privacyStatus);
+      const channelId = text(item.snippet?.channelId);
+
+      // Private and deleted uploads stay in the playlist as placeholders whose
+      // title is literally "Private video" / "Deleted video". Publishing those
+      // as coverage would assert a video that no one can open.
+      if (privacyStatus !== "public") {
+        nonPublic += 1;
+        continue;
+      }
+      if (videoId === "" || title === "" || publishedAt === "") {
+        unusable += 1;
+        continue;
+      }
+      // An upload attributed to another channel does not belong in this
+      // namespace's identity space; a mixed page means the snapshot is wrong.
+      if (channelId !== CHANNEL_ID) {
+        throw new Error(
+          `com.youtube.donutoperator: video ${videoId} in ${path.basename(uploadPath)} ` +
+            `is attributed to channel ${channelId || "(none)"}, not ${CHANNEL_ID}.`,
+        );
+      }
+
+      const url = watchUrl(videoId);
+      records[videoId] = {
+        spec: {
+          url,
+          // Built from the video ID, so it is already the canonical form —
+          // no share links, playlist context, or tracking parameters to strip.
+          normalized_url: url,
+          title,
+          source_name: CHANNEL_DISPLAY_NAME,
+          published_at: publishedAt,
+        },
+      };
+    }
+  }
+
+  log.info(
+    `com.youtube.donutoperator: ${Object.keys(records).length} public uploads ` +
+      `(${nonPublic} private/deleted, ${unusable} missing id/title/publish date) ` +
+      `from ${uploadPaths.length} page(s)`,
+  );
+
+  return { artifacts: [{ kind: "CoverageLinks", records }] };
+};

--- a/test/cli/run/source-order.integration.test.ts
+++ b/test/cli/run/source-order.integration.test.ts
@@ -24,11 +24,14 @@ describe("source run order over the real sources", () => {
 
     // Independent oracle: hand-derived from each source's declared produces and
     // the FK graph (see the derive-source-run-order design doc).
+    // `com.youtube.donutoperator` produces only CoverageLinks, whose FK targets
+    // are empty, so it is unconstrained and lands by the id tiebreak.
     expect(order).toEqual([
       "us-census-gazetteer",
       "gov.tx.tcole",
       "mn-post",
       "clearinghouse-api",
+      "com.youtube.donutoperator",
       "courtlistener",
       "gov.azpost.roster",
       "gov.us.federal-le",

--- a/test/sources/com.youtube.donutoperator/run.test.ts
+++ b/test/sources/com.youtube.donutoperator/run.test.ts
@@ -1,0 +1,212 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, it, expect } from "vitest";
+import {
+  produces,
+  run,
+} from "../../../sources/com.youtube.donutoperator/run.js";
+import {
+  CHANNEL_ID,
+  SUBSCRIBER_SNAPSHOT,
+} from "../../../sources/com.youtube.donutoperator/channel.js";
+import { buildArtifactsEnvelope } from "../../../src/cli/run/source-run.js";
+import { Artifacts } from "../../../src/shared/io/index.js";
+
+const tempDirs: string[] = [];
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((d) => rm(d, { recursive: true })));
+});
+
+function playlistItem(overrides: {
+  videoId?: string;
+  title?: string;
+  videoPublishedAt?: string | null;
+  privacyStatus?: string;
+  channelId?: string;
+}): Record<string, unknown> {
+  return {
+    snippet: {
+      title: overrides.title ?? "Bodycam: traffic stop breakdown",
+      channelId: overrides.channelId ?? CHANNEL_ID,
+    },
+    contentDetails: {
+      videoId: overrides.videoId ?? "aaaaaaaaaaa",
+      ...(overrides.videoPublishedAt === null
+        ? {}
+        : {
+            videoPublishedAt:
+              overrides.videoPublishedAt ?? "2026-03-04T15:00:00Z",
+          }),
+    },
+    status: { privacyStatus: overrides.privacyStatus ?? "public" },
+  };
+}
+
+async function snapshot(
+  pages: Array<Array<Record<string, unknown>>>,
+  channelIds: string[] = [CHANNEL_ID],
+): Promise<string[]> {
+  const dir = await mkdtemp(path.join(tmpdir(), "donutoperator-"));
+  tempDirs.push(dir);
+  const paths: string[] = [];
+
+  const channelPath = path.join(dir, "channel.json");
+  await writeFile(
+    channelPath,
+    JSON.stringify({ items: channelIds.map((id) => ({ id })) }),
+    "utf8",
+  );
+  paths.push(channelPath);
+
+  for (const [index, items] of pages.entries()) {
+    const pagePath = path.join(
+      dir,
+      `uploads-${String(index + 1).padStart(4, "0")}.json`,
+    );
+    await writeFile(pagePath, JSON.stringify({ items }), "utf8");
+    paths.push(pagePath);
+  }
+  return paths;
+}
+
+const deps = (paths: string[]) => ({
+  paths,
+  readXlsx: async () => [],
+  state: "/state",
+  emit: async () => {},
+});
+
+describe("com.youtube.donutoperator run", () => {
+  it("declares only CoverageLinks — no officer associations", () => {
+    expect(produces).toEqual(["CoverageLinks"]);
+  });
+
+  it("emits one CoverageLink per public upload, keyed by video ID", async () => {
+    const paths = await snapshot([
+      [
+        playlistItem({
+          videoId: "dQw4w9WgXcQ",
+          title: "Officer body camera released",
+          videoPublishedAt: "2026-01-15T18:30:00Z",
+        }),
+      ],
+      [playlistItem({ videoId: "9bZkp7q19f0", title: "Second video" })],
+    ]);
+
+    const manifest = await run(deps(paths));
+
+    expect(manifest.artifacts).toHaveLength(1);
+    const coverage = manifest.artifacts[0];
+    expect(coverage.kind).toBe("CoverageLinks");
+    expect(Object.keys(coverage.records).sort()).toEqual([
+      "9bZkp7q19f0",
+      "dQw4w9WgXcQ",
+    ]);
+    expect(coverage.records["dQw4w9WgXcQ"].spec).toEqual({
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      normalized_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      title: "Officer body camera released",
+      source_name: "Donut Operator",
+      published_at: "2026-01-15T18:30:00Z",
+    });
+  });
+
+  it("skips private, deleted, and incomplete playlist entries", async () => {
+    const paths = await snapshot([
+      [
+        playlistItem({ videoId: "keeper00001" }),
+        playlistItem({
+          videoId: "private0001",
+          title: "Private video",
+          privacyStatus: "private",
+        }),
+        playlistItem({
+          videoId: "unlisted001",
+          privacyStatus: "unlisted",
+        }),
+        // Deleted uploads keep their slot but lose videoPublishedAt.
+        playlistItem({ videoId: "deleted0001", videoPublishedAt: null }),
+        playlistItem({ videoId: "", title: "No id" }),
+        playlistItem({ videoId: "notitle0001", title: "" }),
+      ],
+    ]);
+
+    const manifest = await run(deps(paths));
+
+    expect(Object.keys(manifest.artifacts[0].records)).toEqual(["keeper00001"]);
+  });
+
+  it("rejects a snapshot whose channel.json is not the pinned channel", async () => {
+    const paths = await snapshot([[playlistItem({})]], ["UCsomeotherchannel"]);
+
+    await expect(run(deps(paths))).rejects.toThrow(CHANNEL_ID);
+  });
+
+  it("rejects an upload attributed to another channel", async () => {
+    const paths = await snapshot([
+      [playlistItem({ videoId: "foreign0001", channelId: "UCnotdonut" })],
+    ]);
+
+    await expect(run(deps(paths))).rejects.toThrow("UCnotdonut");
+  });
+
+  it("fails loudly when the snapshot has no uploads pages", async () => {
+    const paths = await snapshot([]);
+
+    await expect(run(deps(paths))).rejects.toThrow("uploads-NNNN.json");
+  });
+
+  it("is deterministic", async () => {
+    const paths = await snapshot([
+      [
+        playlistItem({ videoId: "det000000001".slice(0, 11) }),
+        playlistItem({ videoId: "det000000002".slice(0, 11) }),
+      ],
+    ]);
+
+    expect(await run(deps(paths))).toEqual(await run(deps(paths)));
+  });
+
+  it("pins the board-provided rank-1 subscriber snapshot", () => {
+    expect(SUBSCRIBER_SNAPSHOT).toEqual({
+      rank: 1,
+      subscriberCount: 5_310_000,
+      retrievedOn: "2026-08-24",
+    });
+  });
+});
+
+describe("com.youtube.donutoperator artifacts", () => {
+  it("round-trips through root intake's Artifacts read gate", async () => {
+    const paths = await snapshot([
+      [
+        playlistItem({
+          videoId: "dQw4w9WgXcQ",
+          title: "Officer body camera released",
+        }),
+      ],
+    ]);
+    const manifest = await run(deps(paths));
+    const outputDir = await mkdtemp(path.join(tmpdir(), "donutoperator-out-"));
+    tempDirs.push(outputDir);
+
+    const written = await Artifacts.write(
+      outputDir,
+      buildArtifactsEnvelope("com.youtube.donutoperator", "abc123", manifest),
+    );
+    // The same call root intake makes in readArtifactsStage: it parses each
+    // inline record against CoverageLinkSpec and throws on any that fails.
+    const read = await Artifacts.read(written.path, {
+      includeKinds: ["CoverageLinks"],
+    });
+
+    expect(read.metadata.namespace).toBe("com.youtube.donutoperator");
+    expect(read.spec.artifacts).toHaveLength(1);
+    expect(read.spec.artifacts[0].kind).toBe("CoverageLinks");
+    expect(read.spec.artifacts[0].spec.records["dQw4w9WgXcQ"]).toMatchObject({
+      normalized_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      source_name: "Donut Operator",
+    });
+  });
+});


### PR DESCRIPTION
Adds `sources/com.youtube.donutoperator` — rank 1 of the board's subscriber-ordered intake-source queue (~5.31M subscribers, snapshot 2026-08-24).

Based on `redesign-config-driven-intake`, which is where the `sources/<namespace>` design lives.

## What it does

One `CoverageLink` per public upload, keyed by the YouTube video ID. `url` and `normalized_url` are built from that ID, so there is no share-link or tracking-parameter variance for the `coverage_links_normalized_url_key` unique index to trip over. `published_at` is `contentDetails.videoPublishedAt` (when the video was published) rather than `snippet.publishedAt` (when it was added to the uploads playlist).

## Identity is the channel ID, in both phases

`acquire` resolves the channel by `channels.list?id=UCwkm_Wcyh0pc7UUmZZfL-6w` and fails if anything else comes back. `run` re-verifies the archived `channel.json` and every item's `snippet.channelId`, so the guarantee survives replaying a snapshot where `acquire` never runs. Handle and display-name drift is recorded as provenance and logged — a rename is information, not a fault, and must not silently repoint ingestion at a different channel.

## What it deliberately does not do

The source declares `produces: ["CoverageLinks"]` and emits no `CoverageLinkAgencyOfficers`. YouTube gives this source a stable identifier for the *video* and none for the *person*, so linking a video to a named officer would mean matching a name out of a title or description written for an audience. `runSource` already aborts on an undeclared emitted kind, so that is a failed run rather than a review comment. Attaching this coverage to personnel needs a separate reviewed mechanism.

## Access

YouTube Data API v3 only — no scraping, and `YOUTUBE_API_KEY` is required with a loud failure when absent. Retries 429/5xx with capped backoff; never retries a 403 (exhausted quota or bad key), since retrying that evades a limit rather than respecting it. Free within the default 10,000-unit daily quota: `playlistItems.list` costs 1 unit per 50-item page.

## Scope

No registry, schema, migration, envelope, or dependency change — `CoverageLinks` is an existing kind with `dependsOn: []` already wired through the pipeline (mn-post emits it). The only non-additive edit is the `source-order.integration.test.ts` oracle, which gains the new unconstrained source.

## Verification

- `npm run format:check`, `npm run typecheck`, `npm run build`, `npm run openspec:validate` — all pass
- `npm run test:vitest` — 418 tests pass. `test/seed-display.test.ts` fails to load in every local checkout because `supabase/seed.sql` is gitignored and absent; unrelated to this change, which touches no SQL.
- `intake sources` lists `com.youtube.donutoperator [acquire, run]`, `produces: CoverageLinks`, no consumed kinds
- Acceptance test round-trips the manifest through `Artifacts.read({ includeKinds: ["CoverageLinks"] })` — the same call root intake makes, which validates every record against `CoverageLinkSpec`

## Not verified

The channel ID is board-supplied and has not been checked against YouTube: that needs a `YOUTUBE_API_KEY`, which is not provisioned. The first `acquire` is the check, and it fails loudly if `channels.list` does not return exactly that channel.

Refs INS-46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)